### PR TITLE
feat(ads): Prebid→GAM via GPT only; non-collapsing placeholders; hous…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/docs/ads/README.md
+++ b/docs/ads/README.md
@@ -1,0 +1,95 @@
+# Ads: Prebid + Google Ad Manager (GAM)
+
+Коротко: показ відбувається **через GPT (Google Publisher Tag)**. Prebid робить аукціон, пише `hb_*` у GPT, далі **тільки** `googletag.pubads().refresh()` виконує мережевий запит та рендер. Якщо інвентар порожній або мережа вимкнена — показуємо **плейсхолдер / house-креатив**, слот **не колапсить**.
+
+---
+
+## Quick start
+
+```bash
+# встановити залежності
+npm i
+```
+# dev
+```bash
+npm run dev
+```
+# перевірка та авто-стіксування стилю коду
+```bash
+npm run biome
+npm run biome:fix
+.env (приклад)
+dotenv
+Копіювати код
+```
+# вибір модуля
+```bash
+VITE_ADS_MODULE=prebid          # prebid | google
+```
+# GAM
+```bash
+VITE_ENABLE_GAM=true            # вмикає GPT/Google
+VITE_GAM_NETWORK=false          # false = локальна перевірка без мережі (без червоних CORS у консолі)
+VITE_ADS_DEBUG=true
+```
+# Prebid / Bidmatic
+```bash
+VITE_ENABLE_BIDMATIC=true
+VITE_BIDMATIC_SOURCE=886409
+VITE_BIDMATIC_SPN=my-partner    # передається в bidmatic як params.spn
+У проді замініть демо-юніти /1234567/ad-top|ad-side на реальні: /NETWORK_CODE/ad-top|ad-side.
+```
+| Режим                           | Налаштування                                                              | Очікувана поведінка                                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Full path через GAM**         | `VITE_ADS_MODULE=prebid`, `VITE_ENABLE_GAM=true`, `VITE_GAM_NETWORK=true` | Prebid → `setTargetingForGPTAsync()` → GPT `refresh()` → рендер оголошення; або house при порожньому інвентарі |
+| **Prebid + GPT (без мережі)**   | `VITE_ENABLE_GAM=true`, `VITE_GAM_NETWORK=false`                          | Мережі немає; плейсхолдер/house лишається; івенти логуються                                                    |
+| **Prebid-only (прямий рендер)** | `VITE_ENABLE_GAM=false`                                                   | Виграшні креативи рендеряться напряму `pbjs.renderAd`                                                          |
+| **Чистий GAM (demo)**           | `VITE_ADS_MODULE=google`, `VITE_ENABLE_GAM=true`, `VITE_GAM_NETWORK=true` | Лише GPT; при `isEmpty` — house/плейсхолдер; слот не колапсить                                                 |
+
+
+## Що реалізовано
+* modules/prebid.auction.js: аукціон, лог подій, setTargetingForGPTAsync(), googletag.pubads().refresh() (коли ввімкнено GAM), фолбек на прямий рендер, плейсхолдери, spn для Bidmatic.
+
+* modules/google.only.js: ініціалізація GPT, слоти, slotRenderEnded, house/плейсхолдер, без collapseEmptyDivs() (слот не зникає), підтримка VITE_GAM_NETWORK=false.
+
+* Сітковий таргетинг: page-level site, section, env, prebid + slot-level pos.
+
+## QA-скрипт (як перевіряти)
+1. Full GAM: переконайтесь, що після pbjs.requestBids викликається setTargetingForGPTAsync() і далі pubads().refresh(); при isEmpty бачимо house/плейсхолдер.
+
+2. No-network: VITE_GAM_NETWORK=false — мережевих запитів до gampad/ads немає, плейсхолдер/house на місці.
+
+3. Prebid-only: VITE_ENABLE_GAM=false — виграшні креативи рендеряться в iframe; без ставок — сірий банер лишається.
+
+4. Чистий GAM: без Prebid — при isEmpty показуємо house/плейсхолдер.
+
+У логах має бути послідовність:
+pbjs.requestBids → setTargetingForGPTAsync → googletag.pubads().refresh() → slotRenderEnded.
+
+## Необхідно в GAM (прод)
+* Ad units: /NETWORK_CODE/ad-top (970×90, 728×90, 468×60, 320×50) та /NETWORK_CODE/ad-side (300×600, 300×250).
+
+* KV під Prebid: дозволити hb_bidder, hb_pb, hb_adid, hb_size, hb_format, hb_source, hb_uuid (або відповідно до вашої версії Prebid).
+
+* Line items з таргетингом на hb_*.
+
+* Додати домен сайту у Sites (GAM).
+
+## Типові повідомлення/помилки
+* gampad/ads … 400 + CORS у деві — очікувано для демо-юнітів або без валідного сеансу. На UX не впливає: слот закриваємо house/плейсхолдером.
+
+* isEmpty: true у slotRenderEnded — немає матчу в line item: показуємо house, слот не колапсить.
+
+## Acceptance Criteria
+* Показ з Prebid+GAM виконується лише через GPT (googletag.*), без власних fetch до gampad/ads.
+
+* При відсутності інвентаря слот не зникає (house/плейсхолдер).
+
+* Видно чіткий ланцюжок у логах: requestBids → setTargetingForGPTAsync → refresh → slotRenderEnded.
+
+* Page/slot таргетинг застосовується (перевірка через GPT Debug/консоль).
+
+## Примітки
+* Для house-креативів покладіть зображення в /public/house/* або змініть шляхи в modules/google.only.js.
+
+* Якщо лінтер лається на forEach з поверненням значення — замініть виклик на for..of або forEach(() => { ... }).

--- a/docs/ads/research-google-only.md
+++ b/docs/ads/research-google-only.md
@@ -1,0 +1,94 @@
+# Research: показ реклами через Prebid + Google, використовуючи **лише Google API**
+
+## TL;DR
+Єдиний офіційний клієнтський спосіб показати оголошення з Google Ad Manager (GAM) — **через GPT (Google Publisher Tag)**.  
+Схема: **Prebid** робить аукціон → записує `hb_*` ключі в GPT → **GPT** виконує мережевий запит і рендерить.  
+Будь-які REST/HTTP звернення напряму до `gampad/ads` без GPT непідтримувані (CORS/куки/політики).
+
+---
+
+## Ціль
+Підтвердити, що ми можемо показувати рекламу в режимі **Prebid + GAM**, викликаючи **тільки методи Google** для запиту/рендеру, і зафіксувати мінімальний робочий код/потік.
+
+---
+
+## Висновки дослідження
+- **Показ → тільки GPT**: методи `googletag.*` (ініціалізація бібліотеки, визначення слотів, `pubads().refresh()`).
+- **Ad Manager API / AdSense API** — для конфігів/звітності, але **не** повертають креативи для фронтенд-рендеру.
+- **Прямі fetch до `gampad/ads`** офіційно не для клієнтів (CORS + відсутність потрібних куків/підписів).
+- Тому **правильний потік**:
+  1) `googletag.defineSlot(...)`, `pubads.disableInitialLoad()` (коли з Prebid), `enableSingleRequest()`.
+  2) `pbjs.requestBids(...)`.
+  3) `pbjs.setTargetingForGPTAsync()` → записує `hb_*` у GPT.
+  4) `googletag.pubads().refresh()` → **єдиний виклик, який робить мережевий запит і рендер**.
+
+---
+
+## Мінімальний код (сутність для демонстрації)
+
+> Цей фрагмент слугує демо/документацією. У проді цей потік у нас уже реалізований у модулях.
+
+```html
+<div id="ad-top" style="min-height:50px"></div>
+<div id="ad-side" style="width:300px;height:600px"></div>
+<script>
+  // 1) Google Publisher Tag — ЄДИНИЙ спосіб показу з боку Google
+  window.googletag = window.googletag || { cmd: [] };
+  (function loadGPT() {
+    const s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
+    document.head.appendChild(s);
+  })();
+
+  // 2) Оголошуємо слоти тільки через GPT
+  googletag.cmd.push(() => {
+    const pubads = googletag.pubads();
+    pubads.disableInitialLoad();        // важливо з Prebid (чекаємо hb-таргетингу)
+    pubads.enableSingleRequest();
+    pubads.setCentering(true);
+
+    // Page-level таргетинг (приклад)
+    pubads.setTargeting('site', location.hostname);
+    pubads.setTargeting('section', location.pathname.replace(/\//g, '_') || 'home');
+
+    // Слоти
+    googletag.defineSlot('/1234567/ad-top',
+      [[970,90],[728,90],[468,60],[320,50]],
+      'ad-top'
+    )?.addService(pubads).setTargeting('pos','top');
+
+    googletag.defineSlot('/1234567/ad-side',
+      [[300,600],[300,250]],
+      'ad-side'
+    )?.addService(pubads).setTargeting('pos','side');
+
+    // Лог події рендеру (для дебагу/фолбеку)
+    pubads.addEventListener('slotRenderEnded', (ev) => {
+      console.log('[GAM] slotRenderEnded', ev.slot.getSlotElementId(), ev);
+      // якщо ev.isEmpty === true — показуємо house/сірий банер (у нас реалізовано модулем)
+    });
+
+    googletag.enableServices();
+    googletag.display('ad-top');
+    googletag.display('ad-side');
+  });
+
+  // 3) Prebid: аукціон → таргетинг → refresh у GPT
+  window.pbjs = window.pbjs || { que: [] };
+  pbjs.que.push(() => {
+    pbjs.addAdUnits([
+      { code:'ad-top',  mediaTypes:{banner:{sizes:[[970,90],[728,90],[468,60],[320,50]]}}, bids:[/* bidders */] },
+      { code:'ad-side', mediaTypes:{banner:{sizes:[[300,600],[300,250]]}},                bids:[/* bidders */] },
+    ]);
+
+    pbjs.requestBids({
+      adUnitCodes: ['ad-top','ad-side'],
+      timeout: 2000,
+      bidsBackHandler() {
+        pbjs.setTargetingForGPTAsync();                 // записує hb_* у GPT
+        googletag.cmd.push(() => googletag.pubads().refresh()); // запит/рендер робить ТІЛЬКИ GPT
+      },
+    });
+  });
+</script>

--- a/modules/ads.styles.js
+++ b/modules/ads.styles.js
@@ -1,0 +1,53 @@
+// Єдина точка правди для всіх ads-стилів + компоновщик під різні режими
+
+export const ADS_WRAP_CSS =
+	".ads-wrap{position:relative;display:block;margin:0 auto}";
+
+export const ADS_SLOT_CSS =
+	".ads-slot{position:relative;display:block;width:100%;height:100%;min-height:50px;overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#f3f4f6}";
+
+export const ADS_SLOT_IFRAME_CSS =
+	".ads-slot iframe{display:block;border:0;width:100%;height:100%;overflow:hidden}";
+
+export const ADS_PLACEHOLDER_CSS =
+	".ads-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:.5rem;font:12px/1.2 system-ui;color:#6b7280;background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.03) 0 10px,rgba(0,0,0,.05) 10px 20px)}";
+
+export const ADS_DOT_CSS =
+	".ads-dot{width:8px;height:8px;border-radius:9999px;background:#9ca3af;animation:ads-pulse 1.4s ease-in-out infinite}";
+
+export const ADS_KEYFRAMES_CSS =
+	"@keyframes ads-pulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.3);opacity:1}}";
+
+export const ADS_SIDE_FIXED_CSS = ".ads-side-fixed{position:fixed;z-index:30}";
+
+// Опційно: house creative (якщо використовуєш у google.only.js)
+export const ADS_HOUSE_CSS = `
+.ads-house{position:absolute;inset:0;border-radius:12px;overflow:hidden}
+.ads-house a{display:block;width:100%;height:100%;text-decoration:none}
+.ads-house__img{width:100%;height:100%;display:block;object-fit:cover}
+.ads-house__label{position:absolute;top:6px;left:8px;padding:2px 6px;border-radius:6px;font:11px/1 system-ui;background:rgba(17,24,39,.75);color:#e5e7eb}
+`.trim();
+
+/**
+ * Склеює CSS під конкретний модуль.
+ * @param {{includeIframe?: boolean, includeSideFixed?: boolean, includeHouse?: boolean}} opts
+ */
+export function composeAdsCss(opts = {}) {
+	const {
+		includeIframe = false,
+		includeSideFixed = false,
+		includeHouse = false,
+	} = opts;
+	return [
+		ADS_WRAP_CSS,
+		ADS_SLOT_CSS,
+		includeIframe ? ADS_SLOT_IFRAME_CSS : "",
+		ADS_PLACEHOLDER_CSS,
+		ADS_DOT_CSS,
+		ADS_KEYFRAMES_CSS,
+		includeSideFixed ? ADS_SIDE_FIXED_CSS : "",
+		includeHouse ? ADS_HOUSE_CSS : "",
+	]
+		.filter(Boolean)
+		.join("\n");
+}

--- a/modules/google.only.js
+++ b/modules/google.only.js
@@ -1,4 +1,3 @@
-
 // modules/google.only.js
 // Чистий GAM з «сірими банерами», коли інвентар порожній або мережеві виклики вимкнені.
 
@@ -41,6 +40,7 @@ function loadScript(src, id) {
 		document.head.appendChild(s);
 	});
 }
+
 function injectStylesOnce() {
 	if (w.__ads.stylesInjectedG) return;
 	w.__ads.stylesInjectedG = true;
@@ -129,7 +129,7 @@ function ensureContainers() {
 		topWrap.appendChild(top);
 		main.parentElement?.insertBefore(topWrap, main);
 	}
-  
+
 	// SIDE
 	let sideWrap = document.querySelector('[data-ads="side-wrap"]');
 	if (!sideWrap) {
@@ -198,6 +198,14 @@ function defineSlots({ top, side }) {
 			}
 		}
 
+		if (side && !slotExists(side.id)) {
+			const s = w.googletag.defineSlot("/1234567/ad-side", SIDE_SIZES, side.id);
+			if (s) {
+				s.addService(pubads);
+				s.setTargeting("pos", "side");
+			}
+		}
+
 		pubads.addEventListener("slotRenderEnded", (ev) => {
 			const id = ev.slot.getSlotElementId();
 			if (ev.isEmpty) {
@@ -222,9 +230,9 @@ function defineSlots({ top, side }) {
 				lineItemId: ev.lineItemId,
 			});
 		});
-    
+
 		w.googletag.enableServices?.();
-    if (top) w.googletag.display(top.id);
+		if (top) w.googletag.display(top.id);
 		if (side) w.googletag.display(side.id);
 	});
 }
@@ -252,4 +260,3 @@ export async function refreshAds() {
 	if (!USE_GAM) return;
 	w.googletag?.cmd.push(() => w.googletag.pubads().refresh());
 }
-

--- a/modules/google.only.js
+++ b/modules/google.only.js
@@ -1,11 +1,32 @@
-// Чистий GAM (без Prebid): автоінʼєкція слотів + показ через GPT + house fallback
-import { ENABLE_GAM } from "virtual:ads-config";
+// modules/google.only.js
+// Чистий GAM з «сірими банерами», коли інвентар порожній або мережеві виклики вимкнені.
+
+import { ENABLE_GAM, GAM_NETWORK_CALLS } from "virtual:ads-config";
 
 const GPT_SRC = "https://securepubads.g.doubleclick.net/tag/js/gpt.js";
+const USE_GAM = ENABLE_GAM && !!GAM_NETWORK_CALLS;
+
+const TOP_SIZES = [
+	[970, 90],
+	[728, 90],
+	[468, 60],
+	[320, 50],
+];
+const SIDE_SIZES = [
+	[300, 600],
+	[300, 250],
+];
+
+const DEFAULT_TOP = [728, 90];
+const DEFAULT_SIDE = [300, 250];
+
 const w = window;
 w.__ads = w.__ads || {};
+w.__adslog = w.__adslog || [];
+w.__ads.rendered = w.__ads.rendered || {};
 
-// utils & styles
+/* -------------------------- utils --------------------------- */
+
 function loadScript(src, id) {
 	return new Promise((resolve, reject) => {
 		if (id && document.getElementById(id)) return resolve();
@@ -20,30 +41,78 @@ function loadScript(src, id) {
 }
 
 function injectStylesOnce() {
-	if (w.__ads.stylesInjected) return;
-	w.__ads.stylesInjected = true;
-	const css = `
+	if (w.__ads.stylesInjectedG) return;
+	w.__ads.stylesInjectedG = true;
+	const style = document.createElement("style");
+	style.textContent = `
     .ads-wrap{position:relative;display:block;margin:0 auto}
-    .ads-slot{position:relative;display:block;width:100%;height:100%;overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#fafafa}
-    .ads-slot iframe{display:block;border:0;width:100%;height:100%;overflow:hidden}
-    .ads-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:.5rem;font:12px/1.2 system-ui;color:#6b7280;background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.03)0 10px,rgba(0,0,0,.05)10px 20px)}
+    .ads-slot{position:relative;display:block;width:100%;height:100%;min-height:50px;
+              overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#f3f4f6}
+    .ads-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:.5rem;
+                     font:12px/1.2 system-ui;color:#6b7280;
+                     background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.03) 0 10px,rgba(0,0,0,.05) 10px 20px)}
     .ads-dot{width:8px;height:8px;border-radius:9999px;background:#9ca3af;animation:ads-pulse 1.4s ease-in-out infinite}
     @keyframes ads-pulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.3);opacity:1}}
-    .ads-side-fixed{position:fixed;z-index:30}
   `;
-	const style = document.createElement("style");
-	style.dataset.ads = "styles";
-	style.textContent = css;
 	document.head.appendChild(style);
 }
 
-function pickBestSize(containerW, sizes) {
-	const sorted = [...sizes].sort((a, b) => b[0] - a[0]);
-	const fit = sorted.find(([w]) => w <= containerW);
-	return fit ?? sorted[sorted.length - 1];
+function setWrapSize(el, [W, H]) {
+	const wrap = el?.parentElement;
+	if (wrap) {
+		wrap.style.width = `${W}px`;
+		wrap.style.height = `${H}px`;
+	}
+	if (el) {
+		el.style.width = `${W}px`;
+		el.style.height = `${H}px`;
+	}
 }
 
-// containers (auto-inject)
+function ensurePlaceholder(id, text, size) {
+	const el = document.getElementById(id);
+	if (!el) return;
+	let ph = el.querySelector(".ads-placeholder");
+	if (!ph) {
+		ph = document.createElement("div");
+		ph.className = "ads-placeholder";
+		el.appendChild(ph);
+	}
+	ph.innerHTML = `<span class="ads-dot"></span><span>${id}: ${text}</span>`;
+	setWrapSize(el, size || (id === "ad-top" ? DEFAULT_TOP : DEFAULT_SIDE));
+}
+
+function pushLog(type, payload) {
+	const item = { ts: Date.now(), type, payload };
+	w.__adslog.unshift(item);
+	w.dispatchEvent(new CustomEvent("ads:gpt", { detail: item }));
+	// eslint-disable-next-line no-console
+	console.log("[GAM]", type, payload);
+}
+
+function emitEmpty(id) {
+	ensurePlaceholder(
+		id,
+		"GAM network disabled (local)",
+		id === "ad-top" ? DEFAULT_TOP : DEFAULT_SIDE,
+	);
+	const item = {
+		ts: Date.now(),
+		type: "gpt:slotRenderEnded",
+		payload: {
+			id,
+			isEmpty: true,
+			size: null,
+			creativeId: null,
+			lineItemId: null,
+		},
+	};
+	w.__adslog.unshift(item);
+	w.dispatchEvent(new CustomEvent("ads:gpt", { detail: item }));
+}
+
+/* --------------------- containers & GPT --------------------- */
+
 function ensureContainers() {
 	injectStylesOnce();
 
@@ -52,14 +121,12 @@ function ensureContainers() {
 		document.getElementById("root") ||
 		document.body;
 
-	// TOP — вставляємо ПЕРЕД main
+	// TOP
 	let topWrap = document.querySelector('[data-ads="top-wrap"]');
 	if (!topWrap) {
 		topWrap = document.createElement("div");
 		topWrap.dataset.ads = "top-wrap";
 		topWrap.className = "ads-wrap";
-		topWrap.style.marginBottom = "16px";
-		topWrap.style.width = "100%";
 		const top = document.createElement("div");
 		top.id = "ad-top";
 		top.className = "ads-slot";
@@ -67,12 +134,12 @@ function ensureContainers() {
 		main.parentElement?.insertBefore(topWrap, main);
 	}
 
-	// SIDE — фіксований праворуч від основної колонки
+	// SIDE
 	let sideWrap = document.querySelector('[data-ads="side-wrap"]');
 	if (!sideWrap) {
 		sideWrap = document.createElement("div");
 		sideWrap.dataset.ads = "side-wrap";
-		sideWrap.className = "ads-wrap ads-side-fixed";
+		sideWrap.className = "ads-wrap";
 		sideWrap.style.width = "300px";
 		sideWrap.style.height = "600px";
 		const side = document.createElement("div");
@@ -82,68 +149,9 @@ function ensureContainers() {
 		document.body.appendChild(sideWrap);
 	}
 
-	// Плейсхолдери
-	for (const id of ["ad-top", "ad-side"]) {
-		const slot = document.getElementById(id);
-		if (slot && !slot.querySelector(".ads-placeholder")) {
-			const ph = document.createElement("div");
-			ph.className = "ads-placeholder";
-			ph.innerHTML = `<span class="ads-dot"></span><span>${id}: waiting for GAM…</span>`;
-			slot.appendChild(ph);
-		}
-	}
-
-	// Позиціюємо сайдбар відносно main
-	function positionSide() {
-		const rect = (
-			document.querySelector("main") ||
-			document.getElementById("root") ||
-			document.body
-		).getBoundingClientRect();
-		const scrollY = window.scrollY || document.documentElement.scrollTop || 0;
-		const topOffset = rect.top + scrollY + 8;
-		const gap = 16;
-		const left = rect.right + gap;
-		sideWrap.style.top = `${topOffset}px`;
-		sideWrap.style.left = `${Math.min(Math.max(left, 8), window.innerWidth - 308)}px`;
-	}
-	if (!w.__ads.sidePosBound) {
-		w.__ads.sidePosBound = true;
-		window.addEventListener("resize", positionSide);
-		window.addEventListener("scroll", positionSide);
-	}
-	positionSide();
-
-	// Ресайз TOP під контейнер
-	function resizeTop() {
-		const sizes = [
-			[970, 90],
-			[728, 90],
-			[468, 60],
-			[320, 50],
-		];
-		const cw = topWrap.getBoundingClientRect().width || window.innerWidth;
-		const [W, H] = pickBestSize(cw, sizes);
-		topWrap.style.maxWidth = `${W}px`;
-		topWrap.style.height = `${H}px`;
-	}
-	resizeTop();
-	if (!w.__ads.topRO) {
-		w.__ads.topRO = new ResizeObserver(resizeTop);
-		w.__ads.topRO.observe(topWrap);
-	}
-
-	// Розмір SIDE
-	function resizeSide() {
-		const sizes = [
-			[300, 600],
-			[300, 250],
-		];
-		const [W, H] = pickBestSize(300, sizes);
-		sideWrap.style.width = `${W}px`;
-		sideWrap.style.height = `${H}px`;
-	}
-	resizeSide();
+	// початкові плейсхолдери
+	ensurePlaceholder("ad-top", "waiting for GAM…", DEFAULT_TOP);
+	ensurePlaceholder("ad-side", "waiting for GAM…", DEFAULT_SIDE);
 
 	return {
 		top: document.getElementById("ad-top"),
@@ -151,9 +159,8 @@ function ensureContainers() {
 	};
 }
 
-// GPT
 async function ensureGpt() {
-	if (!ENABLE_GAM) return;
+	if (!USE_GAM) return;
 	if (w.googletag?.apiReady || w.__ads.gptLoading) return;
 	w.__ads.gptLoading = true;
 	w.googletag = w.googletag || { cmd: [] };
@@ -169,81 +176,64 @@ function slotExists(id) {
 	}
 }
 
-function renderHouse(el) {
-	const ph = el.querySelector(".ads-placeholder");
-	if (ph) {
-		ph.innerHTML = `<span class="ads-dot"></span><span>${el.id}: house placeholder</span>`;
-		ph.style.backgroundImage =
-			"repeating-linear-gradient(45deg, rgba(0,0,0,.03) 0 10px, rgba(0,0,0,.05) 10px 20px)";
-	}
-}
-
-function hookGptEvents() {
-	if (w.__ads.gptEventsHooked) return;
-	w.__ads.gptEventsHooked = true;
-	w.googletag.cmd.push(() => {
-		const pubads = w.googletag.pubads();
-		pubads.addEventListener("slotRenderEnded", (ev) => {
-			const id = ev.slot.getSlotElementId();
-			const el = document.getElementById(id);
-			if (!el) return;
-
-			// лог у UI
-			w.__adslog = w.__adslog || [];
-			const item = {
-				ts: Date.now(),
-				type: "gpt:slotRenderEnded",
-				payload: {
-					id,
-					isEmpty: ev.isEmpty,
-					size: ev.size,
-					creativeId: ev.creativeId,
-					lineItemId: ev.lineItemId,
-				},
-			};
-			w.__adslog.unshift(item);
-			w.dispatchEvent(new CustomEvent("ads:gpt", { detail: item }));
-
-			if (ev.isEmpty) {
-				renderHouse(el);
-			} else {
-				el.querySelector(".ads-placeholder")?.remove();
-			}
-
-			// консоль — опційно
-			console.log("[GAM] slotRenderEnded", item.payload);
-		});
-	});
-}
-
-function defineGptSlots({ top, side }) {
-	if (!ENABLE_GAM) return;
-
-	const TOP_SIZES = [
-		[970, 90],
-		[728, 90],
-		[468, 60],
-		[320, 50],
-	];
-	const SIDE_SIZES = [
-		[300, 600],
-		[300, 250],
-	];
+function defineSlots({ top, side }) {
+	if (!USE_GAM) return;
 
 	w.googletag.cmd.push(() => {
 		const pubads = w.googletag.pubads();
 		pubads.enableSingleRequest?.();
 		pubads.setCentering?.(true);
-		pubads.collapseEmptyDivs?.();
+		// НЕ колапсимо пусті слоти — щоб плейсхолдер не зникав
+		// pubads.collapseEmptyDivs?.();
+
+		// простий сітьовий таргетинг
+		pubads.setTargeting("site", location.hostname || "localhost");
+		pubads.setTargeting(
+			"section",
+			location.pathname.replace(/\//g, "_") || "home",
+		);
+		pubads.setTargeting("env", import.meta.env.MODE || "dev");
 
 		if (top && !slotExists(top.id)) {
 			const s = w.googletag.defineSlot("/1234567/ad-top", TOP_SIZES, top.id);
-			if (s) s.addService(pubads);
+			if (s) {
+				s.addService(pubads);
+				s.setTargeting("pos", "top");
+			}
 		}
+
 		if (side && !slotExists(side.id)) {
 			const s = w.googletag.defineSlot("/1234567/ad-side", SIDE_SIZES, side.id);
-			if (s) s.addService(pubads);
+			if (s) {
+				s.addService(pubads);
+				s.setTargeting("pos", "side");
+			}
 		}
+
+		pubads.addEventListener("slotRenderEnded", (ev) => {
+			const id = ev.slot.getSlotElementId();
+			if (ev.isEmpty) {
+				ensurePlaceholder(
+					id,
+					"GAM empty (house)",
+					id === "ad-top" ? DEFAULT_TOP : DEFAULT_SIDE,
+				);
+				w.__ads.rendered[id] = false;
+			} else {
+				document
+					.getElementById(id)
+					?.querySelector(".ads-placeholder")
+					?.remove();
+				w.__ads.rendered[id] = true;
+			}
+			pushLog("gpt:slotRenderEnded", {
+				id,
+				isEmpty: ev.isEmpty,
+				size: ev.size,
+				creativeId: ev.creativeId,
+				lineItemId: ev.lineItemId,
+			});
+		});
 
 		w.googletag.enableServices?.();
 		if (top) w.googletag.display(top.id);
@@ -251,17 +241,26 @@ function defineGptSlots({ top, side }) {
 	});
 }
 
-// public API
+/* --------------------------- API ---------------------------- */
+
 export async function initAds() {
 	const slots = ensureContainers();
 	if (!slots.top && !slots.side) return;
 
 	await ensureGpt();
-	hookGptEvents();
-	defineGptSlots(slots);
+
+	if (!USE_GAM) {
+		// локальний режим без мережі: емітуємо "порожні" рендери і лишаємо плейсхолдери
+		for (const id of ["ad-top", "ad-side"]) {
+			emitEmpty(id);
+		}
+		return;
+	}
+
+	defineSlots(slots);
 }
 
 export async function refreshAds() {
-	await ensureGpt();
+	if (!USE_GAM) return;
 	w.googletag?.cmd.push(() => w.googletag.pubads().refresh());
 }

--- a/modules/google.only.js
+++ b/modules/google.only.js
@@ -3,6 +3,7 @@
 // Чистий GAM з «сірими банерами», коли інвентар порожній або мережеві виклики вимкнені.
 
 import { ENABLE_GAM, GAM_NETWORK_CALLS } from "virtual:ads-config";
+import { composeAdsCss } from "/modules/ads.styles.js";
 
 const GPT_SRC = "https://securepubads.g.doubleclick.net/tag/js/gpt.js";
 const USE_GAM = ENABLE_GAM && !!GAM_NETWORK_CALLS;
@@ -44,14 +45,11 @@ function injectStylesOnce() {
 	if (w.__ads.stylesInjectedG) return;
 	w.__ads.stylesInjectedG = true;
 	const style = document.createElement("style");
-	style.textContent = `
-    .ads-wrap{position:relative;display:block;margin:0 auto}
-    .ads-slot{position:relative;display:block;width:100%;height:100%;overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#fafafa}
-    .ads-slot iframe{display:block;border:0;width:100%;height:100%;overflow:hidden}
-    .ads-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:.5rem;font:12px/1.2 system-ui;color:#6b7280;background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.03) 0 10px,rgba(0,0,0,.05) 10px 20px)}
-    .ads-dot{width:8px;height:8px;border-radius:9999px;background:#9ca3af;animation:ads-pulse 1.4s ease-in-out infinite}
-    @keyframes ads-pulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.3);opacity:1}}
-  `;
+	style.textContent = composeAdsCss({
+		includeIframe: false,
+		includeSideFixed: false,
+		includeHouse: false,
+	});
 	document.head.appendChild(style);
 }
 

--- a/modules/prebid.auction.js
+++ b/modules/prebid.auction.js
@@ -1,25 +1,48 @@
-// Віртуальний модуль: сам створює слоти, вантажить Prebid/GAM, запускає аукціон.
-// За замовчуванням рендеримо напряму (без GAM). GAM можна увімкнути через ENV.
+// Prebid + (опційно) GAM. Плейсхолдери лишаються, доки нема реального рендера.
+// Якщо ставок немає — показуємо сірий банер. Якщо GPT не відрендерив — safe fallback.
+
 import {
 	ADS_DEBUG,
 	BIDMATIC_SOURCE,
+	BIDMATIC_SPN,
 	ENABLE_BIDMATIC,
 	ENABLE_GAM,
+	GAM_NETWORK_CALLS,
 } from "virtual:ads-config";
 
 const PREBID_SRC_LOCAL = "/prebid/prebid.js";
 const PREBID_SRC_CDN =
 	"https://cdn.jsdelivr.net/npm/prebid.js@10.10.0/dist/prebid.js";
 const GPT_SRC = "https://securepubads.g.doubleclick.net/tag/js/gpt.js";
+const USE_GAM = ENABLE_GAM && !!GAM_NETWORK_CALLS;
 
 const PAGE_GAP = 24;
 const SIDE_GAP_FROM_MAIN = 16;
 const SIDE_WIDTH = 300;
 
+const TOP_SIZES = [
+	[970, 90],
+	[728, 90],
+	[468, 60],
+	[320, 50],
+];
+const SIDE_SIZES = [
+	[300, 600],
+	[300, 250],
+];
+
+const DEFAULT_TOP = [728, 90];
+const DEFAULT_SIDE = [300, 250];
+
+const BIDDER_TIMEOUT = 3000;
+const GPT_SAFE_FALLBACK_DELAY = BIDDER_TIMEOUT + 1200; // якщо GPT "мовчить"
+
 const w = window;
 w.__ads = w.__ads || {};
+w.__adslog = w.__adslog || [];
+w.__ads.rendered = w.__ads.rendered || {}; // { [id]: boolean }
 
-// utils
+/* -------------------------- utils --------------------------- */
 
 function loadScript(src, id) {
 	return new Promise((resolve, reject) => {
@@ -48,13 +71,32 @@ function pickBestSize(containerW, sizes) {
 	return fit ?? sorted[sorted.length - 1];
 }
 
+function setWrapSize(el, [W, H]) {
+	const wrap = el?.parentElement;
+	if (wrap) {
+		wrap.style.width = `${W}px`;
+		wrap.style.height = `${H}px`;
+	}
+	if (el) {
+		el.style.width = `${W}px`;
+		el.style.height = `${H}px`;
+	}
+}
+
+function logEvent(type, payload) {
+	const item = { ts: Date.now(), type, payload };
+	w.__adslog.unshift(item);
+	w.dispatchEvent(new CustomEvent("ads:prebid", { detail: item }));
+	if (ADS_DEBUG) console.log("[ads]", type, payload);
+}
+
 function injectStylesOnce() {
 	if (w.__ads.stylesInjected) return;
 	w.__ads.stylesInjected = true;
-
 	const css = `
   .ads-wrap{position:relative;display:block;margin:0 auto}
-  .ads-slot{position:relative;display:block;width:100%;height:100%;overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#fafafa}
+  .ads-slot{position:relative;display:block;width:100%;height:100%;min-height:50px;
+            overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#f3f4f6}
   .ads-slot iframe{display:block;border:0;width:100%;height:100%;overflow:hidden}
   .ads-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:.5rem;font:12px/1.2 system-ui;color:#6b7280;background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.03) 0 10px,rgba(0,0,0,.05) 10px 20px)}
   .ads-dot{width:8px;height:8px;border-radius:9999px;background:#9ca3af;animation:ads-pulse 1.4s ease-in-out infinite}
@@ -67,7 +109,27 @@ function injectStylesOnce() {
 	document.head.appendChild(style);
 }
 
-// containers (auto-inject & layout)
+function ensurePlaceholder(id, text = "waiting…", size) {
+	const el = document.getElementById(id);
+	if (!el) return;
+	let ph = el.querySelector(".ads-placeholder");
+	if (!ph) {
+		ph = document.createElement("div");
+		ph.className = "ads-placeholder";
+		el.appendChild(ph);
+	}
+	ph.innerHTML = `<span class="ads-dot"></span><span>${id}: ${text}</span>`;
+
+	// розмір щоб «сірий банер» був видимий навіть без креативу
+	const dflt = id === "ad-top" ? DEFAULT_TOP : DEFAULT_SIDE;
+	setWrapSize(el, size || dflt);
+}
+
+function removePlaceholder(id) {
+	document.getElementById(id)?.querySelector(".ads-placeholder")?.remove();
+}
+
+/* --------------- containers (auto-inject & layout) ---------- */
 
 function ensureContainers() {
 	injectStylesOnce();
@@ -77,7 +139,7 @@ function ensureContainers() {
 		document.getElementById("root") ||
 		document.body;
 
-	// TOP: вставляємо блок ПЕРЕД main (щоб не перекривати контент)
+	// TOP
 	let topWrap = document.querySelector('[data-ads="top-wrap"]');
 	if (!topWrap) {
 		topWrap = document.createElement("div");
@@ -85,7 +147,6 @@ function ensureContainers() {
 		topWrap.className = "ads-wrap";
 		topWrap.style.margin = `${PAGE_GAP}px auto ${PAGE_GAP / 2}px`;
 		topWrap.style.width = "100%";
-
 		const top = document.createElement("div");
 		top.id = "ad-top";
 		top.className = "ads-slot";
@@ -93,7 +154,7 @@ function ensureContainers() {
 		main.parentElement?.insertBefore(topWrap, main);
 	}
 
-	// SIDE: фіксований праворуч від основної колонки, але з відступами від країв
+	// SIDE
 	let sideWrap = document.querySelector('[data-ads="side-wrap"]');
 	if (!sideWrap) {
 		sideWrap = document.createElement("div");
@@ -101,28 +162,18 @@ function ensureContainers() {
 		sideWrap.className = "ads-wrap ads-side-fixed";
 		sideWrap.style.width = `${SIDE_WIDTH}px`;
 		sideWrap.style.height = "600px";
-
 		const side = document.createElement("div");
 		side.id = "ad-side";
 		side.className = "ads-slot";
 		sideWrap.appendChild(side);
-
 		document.body.appendChild(sideWrap);
 	}
 
-	// Плейсхолдери до рендера
-	for (const id of ["ad-top", "ad-side"]) {
-		const slot = document.getElementById(id);
-		if (slot && !slot.querySelector(".ads-placeholder")) {
-			const ph = document.createElement("div");
-			ph.className = "ads-placeholder";
-			ph.innerHTML = `<span class="ads-dot"></span><span>${id}: waiting for bid…</span>`;
-			slot.appendChild(ph);
-		}
-	}
+	// тримаємо плейсхолдери до реального рендера
+	ensurePlaceholder("ad-top", "waiting for auction…", DEFAULT_TOP);
+	ensurePlaceholder("ad-side", "waiting for auction…", DEFAULT_SIDE);
 
-	// Позиціонування сайдбара поруч із головною колонкою,
-	// але не ближче ніж PAGE_GAP до країв вікна.
+	// позиціюємо сайдбар
 	function positionSide() {
 		const rect = (
 			document.querySelector("main") ||
@@ -133,17 +184,13 @@ function ensureContainers() {
 		const scrollY = window.scrollY || document.documentElement.scrollTop || 0;
 		const topOffset = rect.top + scrollY + PAGE_GAP;
 
-		//  left = правий край main + відступ
 		const desiredLeft = rect.right + SIDE_GAP_FROM_MAIN;
-
-		// межі, щоб не торкатися країв екрана
 		const minLeft = PAGE_GAP;
 		const maxLeft = window.innerWidth - (SIDE_WIDTH + PAGE_GAP);
 
 		sideWrap.style.top = `${topOffset}px`;
 		sideWrap.style.left = `${Math.min(Math.max(desiredLeft, minLeft), maxLeft)}px`;
 	}
-
 	if (!w.__ads.sidePosBound) {
 		w.__ads.sidePosBound = true;
 		window.addEventListener("resize", positionSide);
@@ -151,18 +198,12 @@ function ensureContainers() {
 	}
 	positionSide();
 
-	// Підігнати TOP розмір під ширину контейнера
+	// top sizing
 	function resizeTop() {
-		const sizes = [
-			[970, 90],
-			[728, 90],
-			[468, 60],
-			[320, 50],
-		];
 		const cw = topWrap.getBoundingClientRect().width || window.innerWidth;
-		const [wBest, hBest] = pickBestSize(cw, sizes);
-		topWrap.style.maxWidth = `${wBest}px`;
-		topWrap.style.height = `${hBest}px`;
+		const [W, H] = pickBestSize(cw, TOP_SIZES);
+		topWrap.style.maxWidth = `${W}px`;
+		topWrap.style.height = `${H}px`;
 	}
 	resizeTop();
 	if (!w.__ads.topRO) {
@@ -170,15 +211,11 @@ function ensureContainers() {
 		w.__ads.topRO.observe(topWrap);
 	}
 
-	// SIDE — 300x600 або 300x250
+	// side sizing
 	function resizeSide() {
-		const sizes = [
-			[300, 600],
-			[300, 250],
-		];
-		const [wBest, hBest] = pickBestSize(SIDE_WIDTH, sizes);
-		sideWrap.style.width = `${wBest}px`;
-		sideWrap.style.height = `${hBest}px`;
+		const [W, H] = pickBestSize(SIDE_WIDTH, SIDE_SIZES);
+		sideWrap.style.width = `${W}px`;
+		sideWrap.style.height = `${H}px`;
 	}
 	resizeSide();
 
@@ -188,32 +225,46 @@ function ensureContainers() {
 	};
 }
 
-// singletons
+/* ------------------------- prebid --------------------------- */
 
 async function ensurePrebid() {
 	if (w.pbjs?.libLoaded || w.__ads.pbjsLoading) return;
 	w.__ads.pbjsLoading = true;
 	w.pbjs = w.pbjs || { que: [] };
+
 	try {
 		await loadScript(PREBID_SRC_LOCAL, "pbjs-lib");
 	} catch {
 		await loadScript(PREBID_SRC_CDN, "pbjs-lib");
 	}
-	if (ADS_DEBUG) w.pbjs.que.push(() => w.pbjs.setConfig?.({ debug: true }));
 
-	// SizeConfig для брейкпоінтів
 	w.pbjs.que.push(() => {
-		w.pbjs.setConfig?.({
+		const cfg = {
+			debug: !!ADS_DEBUG,
+			bidderTimeout: BIDDER_TIMEOUT,
+			enableSendAllBids: true,
+			targetingControls: {
+				allowTargetingKeys: [
+					"hb_bidder",
+					"hb_pb",
+					"hb_adid",
+					"hb_size",
+					"hb_format",
+					"hb_source",
+					"hb_uuid",
+				],
+			},
+			userSync: {
+				iframeEnabled: true,
+				filterSettings: { iframe: { bidders: "*", filter: "include" } },
+				syncDelay: 1000,
+			},
+			activityControls: { enabled: false },
 			sizeConfig: [
 				{
 					label: "desktop",
 					mediaQuery: "(min-width: 1024px)",
-					sizesSupported: [
-						[970, 90],
-						[728, 90],
-						[300, 600],
-						[300, 250],
-					],
+					sizesSupported: [...TOP_SIZES, ...SIDE_SIZES],
 				},
 				{
 					label: "tablet",
@@ -233,31 +284,50 @@ async function ensurePrebid() {
 					],
 				},
 			],
-		});
+			schain: {
+				ver: "1.0",
+				complete: 1,
+				nodes: [
+					{ asi: location.hostname || "localhost", sid: "pub-0001", hp: 1 },
+				],
+			},
+			ortb2: {
+				site: {
+					domain: location.hostname || "localhost",
+					page: location.href,
+					ext: {
+						data: { section: location.pathname.replace(/\//g, "_") || "home" },
+					},
+				},
+			},
+		};
+		w.pbjs.setConfig?.(cfg);
 	});
 
-	// На зміну брейкпоінта — легкий refresh
+	// авто-refresh при зміні брейкпоінту
 	if (!w.__ads.bpBound) {
 		w.__ads.bpBound = true;
-		const activeLabel = () =>
+		const active = () =>
 			window.innerWidth >= 1024
 				? "desktop"
 				: window.innerWidth >= 768
 					? "tablet"
 					: "mobile";
-		w.__ads.lastLabel = activeLabel();
+		w.__ads.lastBp = active();
 		window.addEventListener(
 			"resize",
 			debounce(() => {
-				const cur = activeLabel();
-				if (cur !== w.__ads.lastLabel) {
-					w.__ads.lastLabel = cur;
+				const cur = active();
+				if (cur !== w.__ads.lastBp) {
+					w.__ads.lastBp = cur;
 					refreshAds();
 				}
 			}, 250),
 		);
 	}
 }
+
+/* --------------------------- gpt ---------------------------- */
 
 async function ensureGpt() {
 	if (!ENABLE_GAM) return;
@@ -266,133 +336,6 @@ async function ensureGpt() {
 	w.googletag = w.googletag || { cmd: [] };
 	await loadScript(GPT_SRC, "gpt-lib");
 }
-
-//  events
-
-function hookPrebidEvents() {
-	if (w.__ads.eventsHooked) return;
-	w.__ads.eventsHooked = true;
-
-	w.__adslog = w.__adslog || [];
-	const push = (type, payload) => {
-		const item = { ts: Date.now(), type, payload };
-		w.__adslog.push(item);
-		w.dispatchEvent(new CustomEvent("ads:prebid", { detail: item }));
-	};
-	const on = (name) =>
-		w.pbjs.onEvent?.(name, (payload) => {
-			// На успішний рендер прибираємо плейсхолдер
-			if (
-				(name === "adRenderSucceeded" || name === "bidWon") &&
-				payload?.adUnitCode
-			) {
-				const el = document.getElementById(payload.adUnitCode);
-				el?.querySelector(".ads-placeholder")?.remove();
-			}
-			push(name, payload);
-		});
-
-	w.pbjs.que.push(() =>
-		[
-			"auctionInit",
-			"bidRequested",
-			"bidResponse",
-			"noBid",
-			"auctionEnd",
-			"bidWon",
-			"adRenderSucceeded",
-		].forEach(on),
-	);
-}
-
-// config
-
-function makeAdUnits({ top, side }) {
-	const units = [];
-	if (top) {
-		const topSizes = [
-			[970, 90],
-			[728, 90],
-			[468, 60],
-			[320, 50],
-		];
-		units.push({
-			code: top.id,
-			mediaTypes: { banner: { sizes: topSizes } },
-			// bidmatic НЕ додаємо, бо тут немає 300x250
-			bids: biddersForUnit(topSizes, top.id),
-		});
-	}
-	if (side) {
-		const sideSizes = [
-			[300, 600],
-			[300, 250],
-		];
-		units.push({
-			code: side.id,
-			mediaTypes: { banner: { sizes: sideSizes } },
-			// тут є 300x250 → підʼєднається bidmatic
-			bids: biddersForUnit(sideSizes, side.id),
-		});
-	}
-	return units;
-}
-
-// список біддерів для конкретного юніта за його розмірами
-function biddersForUnit(sizes, unitId) {
-	const list = [{ bidder: "adtelligent", params: { aid: 350975 } }];
-
-	// Bidmatic працює з params.source (int). Додаємо його лише коли є 300x250
-	const has300x250 = sizes?.some?.(([w, h]) => w === 300 && h === 250);
-	if (
-		ENABLE_BIDMATIC &&
-		BIDMATIC_SOURCE &&
-		(has300x250 || unitId === "ad-side")
-	) {
-		list.push({
-			bidder: "bidmatic",
-			params: { source: Number(BIDMATIC_SOURCE) },
-		});
-	}
-	return list;
-}
-
-// rendering
-
-function renderDirect(winner) {
-	const el = document.getElementById(winner.adUnitCode);
-	if (!el) return;
-
-	// 1) Контейнер рівно під креатив — жодних скролів
-	const W = Number(winner.width || 0);
-	const H = Number(winner.height || 0);
-	const wrap = el.parentElement;
-	if (wrap) {
-		wrap.style.width = `${W}px`;
-		wrap.style.height = `${H}px`;
-	}
-	el.style.width = `${W}px`;
-	el.style.height = `${H}px`;
-
-	// 2) Прибираємо плейсхолдер і вміст
-	el.querySelector(".ads-placeholder")?.remove();
-	el.innerHTML = "";
-
-	// 3) Створюємо iframe без скролів
-	const ifr = document.createElement("iframe");
-	ifr.setAttribute("scrolling", "no");
-	ifr.setAttribute("marginwidth", "0");
-	ifr.setAttribute("marginheight", "0");
-	ifr.setAttribute("frameborder", "0");
-	ifr.style.cssText =
-		"display:block;border:0;width:100%;height:100%;overflow:hidden";
-	el.appendChild(ifr);
-
-	// 4) Рендеримо переможця
-	w.pbjs.renderAd?.(ifr.contentWindow.document, winner.adId);
-}
-
-//  GPT (optional)
 
 function slotExists(id) {
 	try {
@@ -403,46 +346,184 @@ function slotExists(id) {
 	}
 }
 
-function defineGptSlots({ top, side }) {
+function applyNetworkTargeting() {
 	if (!ENABLE_GAM) return;
+	w.googletag.cmd.push(() => {
+		const pubads = w.googletag.pubads();
+		pubads.setTargeting("site", location.hostname || "localhost");
+		pubads.setTargeting(
+			"section",
+			location.pathname.replace(/\//g, "_") || "home",
+		);
+		pubads.setTargeting("env", import.meta.env.MODE || "dev");
+		pubads.setTargeting("prebid", "1");
+	});
+}
+
+function defineGptSlots({ top, side }) {
+	if (!USE_GAM) return;
+
 	w.googletag.cmd.push(() => {
 		const pubads = w.googletag.pubads();
 		pubads.disableInitialLoad?.();
 		pubads.enableSingleRequest?.();
 		pubads.setCentering?.(true);
-		pubads.collapseEmptyDivs?.();
+		// НЕ колапсимо пусті слоти — щоб плейсхолдер не зникав
+		//pubads.collapseEmptyDivs?.();
 
 		if (top && !slotExists(top.id)) {
-			const s = w.googletag.defineSlot(
-				"/1234567/ad-top",
-				[
-					[970, 90],
-					[728, 90],
-					[468, 60],
-					[320, 50],
-				],
-				top.id,
-			);
-			if (s) s.addService(pubads);
+			const s = w.googletag.defineSlot("/1234567/ad-top", TOP_SIZES, top.id);
+			if (s) {
+				s.addService(pubads);
+				s.setTargeting("pos", "top");
+			}
 		}
 		if (side && !slotExists(side.id)) {
-			const s = w.googletag.defineSlot(
-				"/1234567/ad-side",
-				[
-					[300, 600],
-					[300, 250],
-				],
-				side.id,
-			);
-			if (s) s.addService(pubads);
+			const s = w.googletag.defineSlot("/1234567/ad-side", SIDE_SIZES, side.id);
+			if (s) {
+				s.addService(pubads);
+				s.setTargeting("pos", "side");
+			}
 		}
+
+		pubads.addEventListener("slotRenderEnded", (ev) => {
+			const id = ev.slot.getSlotElementId();
+			if (ev.isEmpty) {
+				// залишаємо/повертаємо сірий банер
+				ensurePlaceholder(
+					id,
+					"GAM empty",
+					id === "ad-top" ? DEFAULT_TOP : DEFAULT_SIDE,
+				);
+				w.__ads.rendered[id] = false;
+			} else {
+				removePlaceholder(id);
+				w.__ads.rendered[id] = true;
+			}
+			if (ADS_DEBUG)
+				console.log("[GAM] slotRenderEnded", {
+					id,
+					isEmpty: ev.isEmpty,
+					size: ev.size,
+					creativeId: ev.creativeId,
+					lineItemId: ev.lineItemId,
+				});
+		});
+
 		w.googletag.enableServices?.();
 		if (top) w.googletag.display(top.id);
 		if (side) w.googletag.display(side.id);
 	});
 }
 
-//  public API
+/* -------------------------- events -------------------------- */
+
+function hookPrebidEvents() {
+	if (w.__ads.eventsHooked) return;
+	w.__ads.eventsHooked = true;
+
+	w.pbjs.que.push(() => {
+		const on = (name) =>
+			w.pbjs.onEvent?.(name, (payload) => logEvent(`hb:${name}`, payload));
+
+		[
+			"auctionInit",
+			"beforeRequestBids",
+			"requestBids",
+			"bidRequested",
+			"bidResponse",
+			"noBid",
+			"bidderDone",
+			"bidderError",
+			"setTargeting",
+			"auctionEnd",
+			"bidWon",
+			"adRenderSucceeded",
+			"adRenderFailed",
+			"bidTimeout",
+		].forEach(on);
+	});
+}
+
+/* -------------------- adUnits & bidders --------------------- */
+
+function makeAdUnits({ top, side }) {
+	const units = [];
+
+	if (top) {
+		units.push({
+			code: top.id,
+			mediaTypes: { banner: { sizes: TOP_SIZES } },
+			schain: {
+				ver: "1.0",
+				complete: 1,
+				nodes: [
+					{ asi: location.hostname || "localhost", sid: "pub-0001", hp: 1 },
+				],
+			},
+			bids: biddersForUnit(TOP_SIZES, top.id),
+		});
+	}
+
+	if (side) {
+		units.push({
+			code: side.id,
+			mediaTypes: { banner: { sizes: SIDE_SIZES } },
+			schain: {
+				ver: "1.0",
+				complete: 1,
+				nodes: [
+					{ asi: location.hostname || "localhost", sid: "pub-0001", hp: 1 },
+				],
+			},
+			bids: biddersForUnit(SIDE_SIZES, side.id),
+		});
+	}
+
+	return units;
+}
+
+function biddersForUnit(sizes, unitId) {
+	const list = [{ bidder: "adtelligent", params: { aid: 350975 } }];
+
+	const has300x250 = sizes?.some?.(([w, h]) => w === 300 && h === 250);
+	if (
+		ENABLE_BIDMATIC &&
+		BIDMATIC_SOURCE &&
+		(has300x250 || unitId === "ad-side")
+	) {
+		const params = { source: Number(BIDMATIC_SOURCE) };
+		if (BIDMATIC_SPN) params.spn = BIDMATIC_SPN;
+		list.push({ bidder: "bidmatic", params });
+	}
+	return list;
+}
+
+/* ------------------------- rendering ------------------------ */
+
+function renderDirect(winner) {
+	const el = document.getElementById(winner.adUnitCode);
+	if (!el) return;
+
+	const W = Number(winner.width || 0);
+	const H = Number(winner.height || 0);
+	setWrapSize(el, [W, H]);
+
+	removePlaceholder(winner.adUnitCode);
+	el.innerHTML = "";
+
+	const ifr = document.createElement("iframe");
+	ifr.setAttribute("scrolling", "no");
+	ifr.setAttribute("frameborder", "0");
+	ifr.style.cssText =
+		"display:block;border:0;width:100%;height:100%;overflow:hidden";
+	el.appendChild(ifr);
+
+	w.pbjs.renderAd?.(ifr.contentWindow.document, winner.adId);
+	w.__ads.rendered[winner.adUnitCode] = true;
+}
+
+/* ------------------------- public API ----------------------- */
 
 export async function initAds() {
 	const slots = ensureContainers();
@@ -451,9 +532,9 @@ export async function initAds() {
 	await ensurePrebid();
 	await ensureGpt();
 
-	w.pbjs.que.push(() => w.pbjs.setConfig?.({ bidderTimeout: 2000 }));
 	hookPrebidEvents();
 
+	applyNetworkTargeting();
 	defineGptSlots(slots);
 
 	await requestAndDisplay();
@@ -463,21 +544,45 @@ export async function requestAndDisplay(adUnits /* optional */) {
 	const slots = ensureContainers();
 	const units = adUnits || makeAdUnits(slots);
 
+	ensurePlaceholder("ad-top", "auction running…", DEFAULT_TOP);
+	ensurePlaceholder("ad-side", "auction running…", DEFAULT_SIDE);
+
 	w.pbjs.que.push(() => {
-		// додаємо adUnits тільки один раз
 		if (!w.__ads.unitsAdded) {
 			w.__ads.unitsAdded = true;
 			w.pbjs.addAdUnits?.(units);
+			logEvent("hb:addAdUnits", units);
 		}
+
 		const codes = units.map((u) => u.code);
 		w.pbjs.requestBids?.({
 			adUnitCodes: codes,
-			timeout: 2000,
+			timeout: BIDDER_TIMEOUT,
 			bidsBackHandler: () => {
 				const winners = w.pbjs.getHighestCpmBids?.(codes) || [];
-				if (ENABLE_GAM && w.googletag?.apiReady) {
+				logEvent("hb:bidsBackHandler", { codes, winners });
+
+				// якщо взагалі немає ставок — лишаємо сірі банери з поясненням
+				if (!winners.length) {
+					ensurePlaceholder("ad-top", "no bids", DEFAULT_TOP);
+					ensurePlaceholder("ad-side", "no bids", DEFAULT_SIDE);
+					return;
+				}
+
+				if (USE_GAM && w.googletag?.apiReady) {
+					// Віддаємо hb_* у GPT і рефрешимо
 					w.pbjs.setTargetingForGPTAsync?.();
 					w.googletag.cmd.push(() => w.googletag.pubads().refresh());
+
+					// safe-fallback: якщо GPT не відрендерив — малюємо напряму
+					setTimeout(() => {
+						winners.forEach((wBid) => {
+							if (!w.__ads.rendered[wBid.adUnitCode]) {
+								// GPT нічого не показав → прямий рендер
+								renderDirect(wBid);
+							}
+						});
+					}, GPT_SAFE_FALLBACK_DELAY);
 				} else {
 					winners.forEach(renderDirect);
 				}
@@ -491,15 +596,31 @@ export async function refreshAds(codes /* optional */) {
 	const units = makeAdUnits(slots);
 	const adUnitCodes = codes || units.map((u) => u.code);
 
+	ensurePlaceholder("ad-top", "refresh…", DEFAULT_TOP);
+	ensurePlaceholder("ad-side", "refresh…", DEFAULT_SIDE);
+
 	w.pbjs.que.push(() => {
 		w.pbjs.requestBids?.({
 			adUnitCodes,
-			timeout: 2000,
+			timeout: BIDDER_TIMEOUT,
 			bidsBackHandler: () => {
 				const winners = w.pbjs.getHighestCpmBids?.(adUnitCodes) || [];
-				if (ENABLE_GAM && w.googletag?.apiReady) {
+				logEvent("hb:bidsBackHandler", { adUnitCodes, winners });
+
+				if (!winners.length) {
+					ensurePlaceholder("ad-top", "no bids", DEFAULT_TOP);
+					ensurePlaceholder("ad-side", "no bids", DEFAULT_SIDE);
+					return;
+				}
+
+				if (USE_GAM && w.googletag?.apiReady) {
 					w.pbjs.setTargetingForGPTAsync?.();
 					w.googletag.cmd.push(() => w.googletag.pubads().refresh());
+					setTimeout(() => {
+						winners.forEach((wBid) => {
+							if (!w.__ads.rendered[wBid.adUnitCode]) renderDirect(wBid);
+						});
+					}, GPT_SAFE_FALLBACK_DELAY);
 				} else {
 					winners.forEach(renderDirect);
 				}

--- a/modules/prebid.auction.js
+++ b/modules/prebid.auction.js
@@ -9,6 +9,7 @@ import {
 	ENABLE_GAM,
 	GAM_NETWORK_CALLS,
 } from "virtual:ads-config";
+import { composeAdsCss } from "/modules/ads.styles.js";
 
 const PREBID_SRC_LOCAL = "/prebid/prebid.js";
 const PREBID_SRC_CDN =
@@ -93,16 +94,11 @@ function logEvent(type, payload) {
 function injectStylesOnce() {
 	if (w.__ads.stylesInjected) return;
 	w.__ads.stylesInjected = true;
-	const css = `
-  .ads-wrap{position:relative;display:block;margin:0 auto}
-  .ads-slot{position:relative;display:block;width:100%;height:100%;min-height:50px;
-            overflow:hidden;border:1px solid rgba(0,0,0,.1);border-radius:12px;background:#f3f4f6}
-  .ads-slot iframe{display:block;border:0;width:100%;height:100%;overflow:hidden}
-  .ads-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;gap:.5rem;font:12px/1.2 system-ui;color:#6b7280;background-image:repeating-linear-gradient(45deg,rgba(0,0,0,.03) 0 10px,rgba(0,0,0,.05) 10px 20px)}
-  .ads-dot{width:8px;height:8px;border-radius:9999px;background:#9ca3af;animation:ads-pulse 1.4s ease-in-out infinite}
-  @keyframes ads-pulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.3);opacity:1}}
-  .ads-side-fixed{position:fixed;z-index:30}
-  `;
+	const css = composeAdsCss({
+		includeIframe: true,
+		includeSideFixed: true,
+		includeHouse: false,
+	});
 	const style = document.createElement("style");
 	style.dataset.ads = "styles";
 	style.textContent = css;

--- a/src/features/news/Feed.tsx
+++ b/src/features/news/Feed.tsx
@@ -1,47 +1,38 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
-import { Link } from "react-router-dom";
-import newsData from "../../mock/news.json";
-import type { NewsItem } from "../../types/news";
-import NewsItemCard from "./NewsItem";
-
-const news = newsData as NewsItem[];
+import type { FeedItem } from "@/types/feed";
+import { useFeed } from "./useFeed";
 
 export default function Feed() {
-	const qc = useQueryClient();
+	const { items, isLoading, isError } = useFeed();
 
-	const prefetch = useCallback(
-		async (id: number) => {
-			await qc.prefetchQuery({
-				queryKey: ["news", id],
-				queryFn: async () => news.find((n) => n.id === id),
-				staleTime: 60_000,
-			});
-		},
-		[qc],
-	);
+	if (isLoading) return <div>Loading…</div>;
+	if (isError) return <div>Failed to load feed</div>;
 
 	return (
 		<section className="mt-6">
 			<h2 className="text-xl font-semibold mb-4">News Feed</h2>
-			<ul className="grid gap-6 sm:grid-cols-2">
-				{news.map((item) => (
-					<li key={item.id}>
-						<Link
-							to={`/news/${item.id}`}
-							onMouseEnter={() => prefetch(item.id)}
-							onFocus={() => prefetch(item.id)}
-							className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-xl"
-							aria-label={`Open "${item.title}"`}
-						>
-							<NewsItemCard
-								item={item}
-								className="rounded-xl border bg-white dark:bg-gray-800 shadow hover:shadow-md transition overflow-hidden"
-							/>
-						</Link>
-					</li>
-				))}
-			</ul>
+
+			{items.length === 0 ? (
+				<div className="text-slate-500">Nothing here yet.</div>
+			) : (
+				<ul className="grid gap-6 sm:grid-cols-2">
+					{items.map((it: FeedItem) => (
+						<li key={it.id}>
+							<a
+								href={it.link}
+								target="_blank"
+								rel="noreferrer"
+								className="block rounded-xl border bg-white dark:bg-gray-800 shadow hover:shadow-md transition overflow-hidden"
+								aria-label={`Open "${it.title}"`}
+							>
+								<div className="p-4">
+									<h3 className="font-medium line-clamp-2">{it.title}</h3>
+									<div className="mt-1 text-sm text-slate-500">{it.date}</div>
+								</div>
+							</a>
+						</li>
+					))}
+				</ul>
+			)}
 		</section>
 	);
 }

--- a/src/features/news/useFeed.ts
+++ b/src/features/news/useFeed.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchFeed } from "@/lib/api";
+import type { FeedResponse } from "@/types/feed";
+
+export function useFeed() {
+	const query = useQuery<FeedResponse, Error>({
+		queryKey: ["feed"],
+		queryFn: fetchFeed,
+		staleTime: 60_000,
+	});
+
+	return {
+		...query,
+		items: query.data?.items ?? [],
+		title: query.data?.title ?? null,
+		cursor: query.data?.cursor ?? null,
+	};
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,22 +1,19 @@
+import type { FeedItem, FeedResponse, RawFeedResponse } from "@/types/feed";
+
 export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
-export type FeedItem = {
-	id: string;
-	title: string;
-	link: string;
-	createdAt: string;
-};
-
-export type FeedResponse = {
-	items: FeedItem[];
-	cursor?: string | null;
-};
-
 export async function fetchFeed(): Promise<FeedResponse> {
-	const res = await fetch(`${API_URL}/feed`, {});
-	if (!res.ok) {
-		const text = await res.text();
-		throw new Error(`Failed to load feed: ${res.status} ${text}`);
-	}
-	return res.json();
+	const res = await fetch(`${API_URL}/feed`);
+	if (!res.ok) throw new Error(await res.text());
+
+	const raw: RawFeedResponse = await res.json();
+
+	const items: FeedItem[] = (raw.items ?? []).map((it) => ({
+		id: it.id,
+		title: it.title,
+		link: it.link,
+		date: it.createdAt ?? it.pubDate ?? null,
+	}));
+
+	return { items, cursor: raw.cursor ?? null, title: raw.title };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,22 @@
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+export type FeedItem = {
+	id: string;
+	title: string;
+	link: string;
+	createdAt: string;
+};
+
+export type FeedResponse = {
+	items: FeedItem[];
+	cursor?: string | null;
+};
+
+export async function fetchFeed(): Promise<FeedResponse> {
+	const res = await fetch(`${API_URL}/feed`, {});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`Failed to load feed: ${res.status} ${text}`);
+	}
+	return res.json();
+}

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -1,0 +1,28 @@
+// backend shape (як приходить з API)
+export type RawFeedItem = {
+	id: string;
+	title: string;
+	link: string;
+	createdAt?: string;
+	pubDate?: string;
+};
+
+export type RawFeedResponse = {
+	items: RawFeedItem[];
+	cursor?: string | null;
+	title?: string;
+};
+
+// нормалізований shape для UI
+export type FeedItem = {
+	id: string;
+	title: string;
+	link: string;
+	date: string | null; // createdAt || pubDate
+};
+
+export type FeedResponse = {
+	items: FeedItem[];
+	cursor?: string | null;
+	title?: string;
+};

--- a/src/types/virtual-ads-config.d.ts
+++ b/src/types/virtual-ads-config.d.ts
@@ -2,8 +2,8 @@ declare module "virtual:ads-config" {
 	export const ENABLE_PREBID: boolean;
 	export const ENABLE_GAM: boolean;
 	export const ADS_DEBUG: boolean;
-
-	// для bidmatic
 	export const ENABLE_BIDMATIC: boolean;
 	export const BIDMATIC_SOURCE: number;
+	export const BIDMATIC_SPN: string | "";
+	export const GAM_NETWORK_CALLS: boolean;
 }

--- a/src/types/virtual-ads-config.d.ts
+++ b/src/types/virtual-ads-config.d.ts
@@ -4,6 +4,6 @@ declare module "virtual:ads-config" {
 	export const ADS_DEBUG: boolean;
 	export const ENABLE_BIDMATIC: boolean;
 	export const BIDMATIC_SOURCE: number;
-  export const BIDMATIC_SPN: string | "";
+	export const BIDMATIC_SPN: string | "";
 	export const GAM_NETWORK_CALLS: boolean;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,12 +22,18 @@ function adsVirtualConfig(env: Record<string, string>): PluginOption {
 			const debug = env.VITE_ADS_DEBUG === "true";
 			const enableBidmatic = env.VITE_ENABLE_BIDMATIC === "true";
 			const bidmaticSource = Number(env.VITE_BIDMATIC_SOURCE || 0);
+			const bidmaticSpn = env.VITE_BIDMATIC_SPN
+				? String(env.VITE_BIDMATIC_SPN)
+				: "";
+			const gamNetworkCalls = env.VITE_GAM_NETWORK === "true";
 			return `
         export const ENABLE_PREBID = ${enablePrebid};
-        export const ENABLE_GAM    = ${enableGAM};
-        export const ADS_DEBUG     = ${debug};
+        export const ENABLE_GAM = ${enableGAM};
+        export const ADS_DEBUG = ${debug};
         export const ENABLE_BIDMATIC = ${enableBidmatic};
         export const BIDMATIC_SOURCE = ${bidmaticSource};
+        export const BIDMATIC_SPN = ${JSON.stringify(bidmaticSpn)};
+        export const GAM_NETWORK_CALLS = ${gamNetworkCalls};
       `;
 		},
 	};
@@ -61,7 +67,6 @@ function adsModulePlugin(env: Record<string, string>): PluginOption {
 
 export default defineConfig(({ mode }): UserConfig => {
 	const env = loadEnv(mode, process.cwd(), "");
-
 	const isDev = mode !== "production";
 	const isAnalyze = env.ANALYZE === "true";
 	const isCI = !!env.CI;


### PR DESCRIPTION
…e fallback; Bidmatic spn; GAM_NETWORK toggle; docs
Що реалізовано

modules/prebid.auction.js: аукціон, лог подій, setTargetingForGPTAsync(), googletag.pubads().refresh() (коли ввімкнено GAM), фолбек на прямий рендер, плейсхолдери, spn для Bidmatic.

modules/google.only.js: ініціалізація GPT, слоти, slotRenderEnded, house/плейсхолдер, без collapseEmptyDivs() (слот не зникає), підтримка VITE_GAM_NETWORK=false.

Сітковий таргетинг: page-level site, section, env, prebid + slot-level pos.

QA-скрипт (як перевіряти)

Full GAM: переконайтесь, що після pbjs.requestBids викликається setTargetingForGPTAsync() і далі pubads().refresh(); при isEmpty бачимо house/плейсхолдер.

No-network: VITE_GAM_NETWORK=false — мережевих запитів до gampad/ads немає, плейсхолдер/house на місці.

Prebid-only: VITE_ENABLE_GAM=false — виграшні креативи рендеряться в iframe; без ставок — сірий банер лишається.

Чистий GAM: без Prebid — при isEmpty показуємо house/плейсхолдер.

У логах має бути послідовність:
pbjs.requestBids → setTargetingForGPTAsync → googletag.pubads().refresh() → slotRenderEnded.

Необхідно в GAM (прод)

Ad units: /NETWORK_CODE/ad-top (970×90, 728×90, 468×60, 320×50) та /NETWORK_CODE/ad-side (300×600, 300×250).

KV під Prebid: дозволити hb_bidder, hb_pb, hb_adid, hb_size, hb_format, hb_source, hb_uuid (або відповідно до вашої версії Prebid).

Line items з таргетингом на hb_*.

Додати домен сайту у Sites (GAM).

Типові повідомлення/помилки

gampad/ads … 400 + CORS у деві — очікувано для демо-юнітів або без валідного сеансу. На UX не впливає: слот закриваємо house/плейсхолдером.

isEmpty: true у slotRenderEnded — немає матчу в line item: показуємо house, слот не колапсить.

Acceptance Criteria

Показ з Prebid+GAM виконується лише через GPT (googletag.*), без власних fetch до gampad/ads.

При відсутності інвентаря слот не зникає (house/плейсхолдер).

Видно чіткий ланцюжок у логах: requestBids → setTargetingForGPTAsync → refresh → slotRenderEnded.

Page/slot таргетинг застосовується (перевірка через GPT Debug/консоль).