### PR TITLE
feat(front): analytics client + stats grid (event hooks, reliable del…

### DIFF
--- a/modules/analytics.module.js
+++ b/modules/analytics.module.js
@@ -1,0 +1,230 @@
+const Q = [];
+let T = null;
+let backoffMs = 0;
+
+const FLUSH_MS = 1500;
+const BATCH_MAX = 50;
+const ENDPOINT = "/api/report";
+const SOFT_PAYLOAD_LIMIT = 60 * 1024;
+let ctx = {};
+
+function sizeOf(obj) {
+	try {
+		return new Blob([JSON.stringify(obj)]).size;
+	} catch {
+		return 0;
+	}
+}
+function splitBySize(events, limitBytes) {
+	const chunks = [];
+	let cur = [];
+	let curBytes = 2;
+
+	for (const e of events) {
+		const eBytes = sizeOf(e) + (cur.length ? 1 : 0);
+		if (cur.length >= BATCH_MAX || curBytes + eBytes > limitBytes) {
+			chunks.push(cur);
+			cur = [];
+			curBytes = 2;
+		}
+		cur.push(e);
+		curBytes += eBytes;
+	}
+	if (cur.length) chunks.push(cur);
+	return chunks;
+}
+
+function scheduleFlush() {
+	if (T) return;
+	const delay = Math.max(FLUSH_MS, backoffMs);
+	T = setTimeout(() => {
+		T = null;
+		flushNow();
+	}, delay);
+}
+
+async function flushNow() {
+	if (Q.length === 0) return;
+
+	const take = Q.splice(0, Math.max(BATCH_MAX, Q.length));
+	const batches = splitBySize(take, SOFT_PAYLOAD_LIMIT);
+
+	for (const batch of batches) {
+		const payload = JSON.stringify(batch);
+
+		if (navigator.sendBeacon) {
+			const ok = navigator.sendBeacon(
+				ENDPOINT,
+				new Blob([payload], { type: "application/json" }),
+			);
+			if (ok) {
+				backoffMs = 0;
+				continue;
+			}
+		}
+
+		try {
+			await fetch(ENDPOINT, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: payload,
+				keepalive: true,
+			});
+			backoffMs = 0;
+		} catch {
+			Q.unshift(...batch);
+			backoffMs = Math.min((backoffMs || 1000) * 2, 10_000);
+			scheduleFlush();
+			return;
+		}
+	}
+
+	if (Q.length) scheduleFlush();
+}
+
+export function initAnalytics(options = {}) {
+	const { enabled = true, context = {} } = options;
+	if (!enabled) return;
+	ctx = { ...context };
+
+	emit({ event: "pageLoad" });
+
+	addEventListener(
+		"pagehide",
+		() => {
+			void flushNow();
+		},
+		{ capture: true },
+	);
+	addEventListener("visibilitychange", () => {
+		if (document.visibilityState === "hidden") {
+			void flushNow();
+		}
+	});
+	addEventListener(
+		"beforeunload",
+		() => {
+			void flushNow();
+		},
+		{ capture: true },
+	);
+	addEventListener("online", () => {
+		scheduleFlush();
+	});
+
+	window.__analytics = {
+		adModuleLoad(extra = {}) {
+			emit({ event: "adModuleLoad", ...extra });
+		},
+		auctionInit(extra = {}) {
+			emit({ event: "auctionInit", ...extra });
+		},
+		auctionEnd(extra = {}) {
+			emit({ event: "auctionEnd", ...extra });
+		},
+		bidRequested(extra = {}) {
+			emit({ event: "bidRequested", ...extra });
+		},
+		bidResponse(extra = {}) {
+			emit({ event: "bidResponse", ...extra });
+		},
+		bidWon(extra = {}) {
+			emit({ event: "bidWon", wins: 1, ...extra });
+		},
+	};
+
+	const pb = window.pbjs;
+	if (pb?.onEvent) {
+		pb.onEvent("auctionInit", (d) =>
+			emit({ event: "auctionInit", adapter: "prebid", ...pickAuction(d) }),
+		);
+		pb.onEvent("auctionEnd", (d) =>
+			emit({ event: "auctionEnd", adapter: "prebid", ...pickAuction(d) }),
+		);
+		pb.onEvent("bidRequested", (d) =>
+			emit({ event: "bidRequested", adapter: "prebid", ...pickBidReq(d) }),
+		);
+		pb.onEvent("bidResponse", (d) =>
+			emit({
+				event: "bidResponse",
+				adapter: "prebid",
+				cpm: d?.cpm,
+				adUnitCode: d?.adUnitCode,
+				bidder: d?.bidder,
+				creativeId: d?.creativeId,
+				adomain: d?.meta?.advertiserDomains || [],
+			}),
+		);
+		pb.onEvent("bidWon", (d) =>
+			emit({
+				event: "bidWon",
+				adapter: "prebid",
+				cpm: d?.cpm,
+				adUnitCode: d?.adUnitCode,
+				bidder: d?.bidder,
+				creativeId: d?.creativeId,
+				adomain: d?.meta?.advertiserDomains || [],
+				wins: 1,
+			}),
+		);
+	}
+}
+
+function emit(ev) {
+	const base = {
+		ts: Date.now(),
+		uid: getUid(),
+		sid: getSid(),
+		page: location.href,
+		ref: document.referrer || null,
+		lang: navigator.language,
+		tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+		cur: "USD",
+		...ctx,
+	};
+	Q.push({ ...base, ...ev });
+	if (Q.length >= BATCH_MAX) {
+		void flushNow();
+	} else {
+		scheduleFlush();
+	}
+}
+
+function getUid() {
+	try {
+		const k = "uid";
+		let id = localStorage.getItem(k);
+		if (!id) {
+			id = crypto.randomUUID();
+			localStorage.setItem(k, id);
+		}
+		return id;
+	} catch {
+		return null;
+	}
+}
+function getSid() {
+	try {
+		const k = "sid";
+		const now = Date.now();
+		const ttl = 30 * 60 * 1000;
+		const raw = sessionStorage.getItem(k);
+		const sid = raw ? JSON.parse(raw) : { id: crypto.randomUUID(), ts: now };
+		if (now - sid.ts > ttl) {
+			sid.id = crypto.randomUUID();
+			sid.ts = now;
+		}
+		sessionStorage.setItem(k, JSON.stringify(sid));
+		return sid.id;
+	} catch {
+		return null;
+	}
+}
+function pickAuction(d) {
+	return { auctionId: d?.auctionId, timeout: d?.timeout };
+}
+function pickBidReq(d) {
+	const code =
+		(Array.isArray(d?.bids) && d.bids[0]?.adUnitCode) || d?.adUnitCode;
+	return { adUnitCode: code };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
 				"@hookform/resolvers": "^5.2.2",
 				"@radix-ui/react-dialog": "^1.1.15",
 				"@tanstack/react-query": "^5.89.0",
-				"gulp": "^5.0.1",
+				"@tanstack/react-table": "^8.21.3",
+				"p-retry": "^7.0.0",
 				"react": "^19.1.1",
 				"react-dom": "^19.1.1",
 				"react-hook-form": "^7.62.0",
 				"react-router-dom": "^7.9.1",
+				"recharts": "^3.2.1",
 				"use-sync-external-store": "^1.5.0",
 				"zod": "^4.1.8",
 				"zustand": "^5.0.8"
@@ -1207,27 +1209,6 @@
 			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
 			"license": "MIT"
 		},
-		"node_modules/@gulpjs/messages": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@gulpjs/messages/-/messages-1.1.0.tgz",
-			"integrity": "sha512-Ys9sazDatyTgZVb4xPlDufLweJ/Os2uHWOv+Caxvy2O85JcnT4M3vc73bi8pdLWlv3fdWQz3pdI9tVwo8rQQSg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/@gulpjs/to-absolute-glob": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@gulpjs/to-absolute-glob/-/to-absolute-glob-4.0.0.tgz",
-			"integrity": "sha512-kjotm7XJrJ6v+7knhPaRgaT6q8F8K2jiafwYdNHLzmV0uGLuZY43FK6smNSHUPrhq5kX2slCUy+RGG/xGqmIKA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-negated-glob": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/@headlessui/react": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.8.tgz",
@@ -2211,6 +2192,32 @@
 				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
 			}
 		},
+		"node_modules/@reduxjs/toolkit": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+			"integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/utils": "^0.3.0",
+				"immer": "^10.0.3",
+				"redux": "^5.0.1",
+				"redux-thunk": "^3.1.0",
+				"reselect": "^5.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+				"react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-redux": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-beta.35",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz",
@@ -2554,6 +2561,12 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
 			"integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
 			"license": "MIT"
 		},
 		"node_modules/@standard-schema/utils": {
@@ -3186,6 +3199,26 @@
 				"react": "^18 || ^19"
 			}
 		},
+		"node_modules/@tanstack/react-table": {
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+			"integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/table-core": "8.21.3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": ">=16.8",
+				"react-dom": ">=16.8"
+			}
+		},
 		"node_modules/@tanstack/react-virtual": {
 			"version": "3.13.12",
 			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
@@ -3201,6 +3234,19 @@
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/table-core": {
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+			"integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
 		"node_modules/@tanstack/virtual-core": {
@@ -3479,6 +3525,69 @@
 				"@types/deep-eql": "*"
 			}
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+			"integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3615,6 +3724,12 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/use-sync-external-store": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+			"integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/yargs": {
@@ -3997,6 +4112,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4006,6 +4122,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -4033,31 +4150,6 @@
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"license": "ISC",
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
 		},
 		"node_modules/app-module-path": {
 			"version": "2.2.0",
@@ -4108,24 +4200,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/array-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-			"integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/array-slice": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-			"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4166,60 +4240,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/async-done": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/async-done/-/async-done-2.0.0.tgz",
-			"integrity": "sha512-j0s3bzYq9yKIVLKGE/tWlCpa3PfFLcrDZLTSVdnnCTGagXuXBJO4SsY9Xdk/fQBirCkH4evW5xOeJXqlAQFdsw==",
-			"license": "MIT",
-			"dependencies": {
-				"end-of-stream": "^1.4.4",
-				"once": "^1.4.0",
-				"stream-exhaust": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/async-settle": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/async-settle/-/async-settle-2.0.0.tgz",
-			"integrity": "sha512-Obu/KE8FurfQRN6ODdHN9LuXqwC+JFIM9NRyZqJJ4ZfLJmIYN9Rg0/kb+wF70VV5+fJusTMQlJ1t5rF7J/ETdg==",
-			"license": "MIT",
-			"dependencies": {
-				"async-done": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/b4a": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
-			"integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
-			"license": "Apache-2.0",
-			"peerDependencies": {
-				"react-native-b4a": "*"
-			},
-			"peerDependenciesMeta": {
-				"react-native-b4a": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/bach": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bach/-/bach-2.0.1.tgz",
-			"integrity": "sha512-A7bvGMGiTOxGMpNupYl9HQTf0FFDNF4VCmks4PJpFyN1AX2pdKuxuwdvUz2Hu388wcgp+OvGFNsumBfFNkR7eg==",
-			"license": "MIT",
-			"dependencies": {
-				"async-done": "^2.0.0",
-				"async-settle": "^2.0.0",
-				"now-and-later": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4227,16 +4247,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/bare-events": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.7.0.tgz",
-			"integrity": "sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4271,18 +4286,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
-			}
-		},
-		"node_modules/binary-extensions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/birpc": {
@@ -4321,6 +4324,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -4495,6 +4499,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -4603,6 +4608,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
 			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -4640,6 +4646,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -4652,6 +4659,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/commander": {
@@ -4682,6 +4690,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
@@ -4691,19 +4700,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/copy-props": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/copy-props/-/copy-props-4.0.0.tgz",
-			"integrity": "sha512-bVWtw1wQLzzKiYROtvNlbJgxgBYt2bMJpkCbKmXM3xyijvcjjWXEk5nyrrT3bgJ7ODb19ZohE2T0Y3FgNPyoTw==",
-			"license": "MIT",
-			"dependencies": {
-				"each-props": "^3.0.0",
-				"is-plain-object": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
 			}
 		},
 		"node_modules/cosmiconfig": {
@@ -4789,6 +4785,127 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/data-urls": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
@@ -4826,6 +4943,12 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/decimal.js-light": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
 			"license": "MIT"
 		},
 		"node_modules/deep-eql": {
@@ -5002,6 +5125,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5186,19 +5310,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/each-props": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/each-props/-/each-props-3.0.0.tgz",
-			"integrity": "sha512-IYf1hpuWrdzse/s/YJOrFmU15lyhSzxelNVAHTEG3DtP4QsLTWZUzcUL3HMXmKQxXpa4EIrBPpwRgj0aehdvAw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^5.0.0",
-				"object.defaults": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.222",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
@@ -5210,16 +5321,8 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-			"license": "MIT",
-			"dependencies": {
-				"once": "^1.4.0"
-			}
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.3",
@@ -5275,6 +5378,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/es-toolkit": {
+			"version": "1.39.10",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+			"integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
+		},
 		"node_modules/esbuild": {
 			"version": "0.25.10",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
@@ -5321,6 +5434,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -5412,19 +5526,17 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/events-universal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"bare-events": "^2.7.0"
-			}
+		"node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"license": "MIT"
 		},
 		"node_modules/expand-tilde": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
 			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"homedir-polyfill": "^1.0.1"
@@ -5461,18 +5573,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"license": "MIT"
-		},
-		"node_modules/fast-fifo": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-			"license": "MIT"
-		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5490,28 +5590,11 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-levenshtein": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
-			"integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
-			"license": "MIT",
-			"dependencies": {
-				"fastest-levenshtein": "^1.0.7"
-			}
-		},
-		"node_modules/fastest-levenshtein": {
-			"version": "1.0.16",
-			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.9.1"
-			}
-		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
 			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -5575,6 +5658,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -5587,6 +5671,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
 			"integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"detect-file": "^1.0.0",
@@ -5596,52 +5681,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/fined": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-2.0.0.tgz",
-			"integrity": "sha512-OFRzsL6ZMHz5s0JrsEr+TpdGNCtrVtnuG3x1yzGNiQHT0yaDnXAj8V/lWcpJVrnoDpcwXcASxAZYbuXda2Y82A==",
-			"license": "MIT",
-			"dependencies": {
-				"expand-tilde": "^2.0.2",
-				"is-plain-object": "^5.0.0",
-				"object.defaults": "^1.1.0",
-				"object.pick": "^1.3.0",
-				"parse-filepath": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/flagged-respawn": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-2.0.0.tgz",
-			"integrity": "sha512-Gq/a6YCi8zexmGHMuJwahTGzXlAZAOsbCVKduWXC6TlLCjjFRlExMJc4GC2NYPYZ0r/brw9P7CpRgQmlPVeOoA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/for-own": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-			"integrity": "sha512-0OABksIGrxKK8K4kynWkQ7y1zounQxP+CWnyclVwj81KW3vlLlGUx57DKGcP/LH216GzqnstnPocF16Nxs0Ycg==",
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -5659,19 +5698,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/fs-mkdirp-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-2.0.1.tgz",
-			"integrity": "sha512-UTOY+59K6IA94tec8Wjqm0FSh5OVudGNB0NL/P6fB3HiE3bYOY3VYBGijsnOHNkQSwC1FKkU77pmq7xp9CskLw==",
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.8",
-				"streamx": "^2.12.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5683,6 +5709,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5697,6 +5724,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5730,6 +5758,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
@@ -5777,80 +5806,13 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/glob-stream": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-8.0.3.tgz",
-			"integrity": "sha512-fqZVj22LtFJkHODT+M4N1RJQ3TjnnQhfE9GwZI8qXscYarnhpip70poMldRnP8ipQ/w0B621kOhfc53/J9bd/A==",
-			"license": "MIT",
-			"dependencies": {
-				"@gulpjs/to-absolute-glob": "^4.0.0",
-				"anymatch": "^3.1.3",
-				"fastq": "^1.13.0",
-				"glob-parent": "^6.0.2",
-				"is-glob": "^4.0.3",
-				"is-negated-glob": "^1.0.0",
-				"normalize-path": "^3.0.0",
-				"streamx": "^2.12.5"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/glob-stream/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/glob-watcher": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-6.0.0.tgz",
-			"integrity": "sha512-wGM28Ehmcnk2NqRORXFOTOR064L4imSw3EeOqU5bIwUf62eXGwg89WivH6VMahL8zlQHeodzvHpXplrqzrz3Nw==",
-			"license": "MIT",
-			"dependencies": {
-				"async-done": "^2.0.0",
-				"chokidar": "^3.5.3"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/glob-watcher/node_modules/chokidar": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-			"license": "MIT",
-			"dependencies": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
-			},
-			"engines": {
-				"node": ">= 8.10.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
@@ -5881,6 +5843,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-prefix": "^1.0.1",
@@ -5895,6 +5858,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
 			"integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"expand-tilde": "^2.0.2",
@@ -5905,18 +5869,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/glogg": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-2.2.0.tgz",
-			"integrity": "sha512-eWv1ds/zAlz+M1ioHsyKJomfY7jbDDPpwSkv14KQj89bycx1nvK5/2Cj/T9g7kzJcX5Bc7Yv22FjfBZS/jl94A==",
-			"license": "MIT",
-			"dependencies": {
-				"sparkles": "^2.1.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
 			}
 		},
 		"node_modules/gonzales-pe": {
@@ -5939,68 +5891,14 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/gulp": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/gulp/-/gulp-5.0.1.tgz",
-			"integrity": "sha512-PErok3DZSA5WGMd6XXV3IRNO0mlB+wW3OzhFJLEec1jSERg2j1bxJ6e5Fh6N6fn3FH2T9AP4UYNb/pYlADB9sA==",
-			"license": "MIT",
-			"dependencies": {
-				"glob-watcher": "^6.0.0",
-				"gulp-cli": "^3.1.0",
-				"undertaker": "^2.0.0",
-				"vinyl-fs": "^4.0.2"
-			},
-			"bin": {
-				"gulp": "bin/gulp.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/gulp-cli": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-3.1.0.tgz",
-			"integrity": "sha512-zZzwlmEsTfXcxRKiCHsdyjZZnFvXWM4v1NqBJSYbuApkvVKivjcmOS2qruAJ+PkEHLFavcDKH40DPc1+t12a9Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@gulpjs/messages": "^1.1.0",
-				"chalk": "^4.1.2",
-				"copy-props": "^4.0.0",
-				"gulplog": "^2.2.0",
-				"interpret": "^3.1.1",
-				"liftoff": "^5.0.1",
-				"mute-stdout": "^2.0.0",
-				"replace-homedir": "^2.0.0",
-				"semver-greatest-satisfied-range": "^2.0.0",
-				"string-width": "^4.2.3",
-				"v8flags": "^4.0.0",
-				"yargs": "^16.2.0"
-			},
-			"bin": {
-				"gulp": "bin/gulp.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/gulplog": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-2.2.0.tgz",
-			"integrity": "sha512-V2FaKiOhpR3DRXZuYdRLn/qiY0yI5XmqbTKrYbdemJ+xOh2d2MOweI/XFgMzd/9+1twdvMwllnZbWZNJ+BOm4A==",
-			"license": "MIT",
-			"dependencies": {
-				"glogg": "^2.2.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6010,6 +5908,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -6022,6 +5921,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
 			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"parse-passwd": "^1.0.0"
@@ -6091,6 +5991,7 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6103,6 +6004,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6127,6 +6029,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/immer": {
+			"version": "10.1.3",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+			"integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
 			}
 		},
 		"node_modules/import-fresh": {
@@ -6182,34 +6094,23 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/interpret": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
-			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
-			"license": "MIT",
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"license": "ISC",
 			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/is-absolute": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-relative": "^1.0.0",
-				"is-windows": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=12"
 			}
 		},
 		"node_modules/is-arrayish": {
@@ -6219,22 +6120,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"license": "MIT",
-			"dependencies": {
-				"binary-extensions": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
 			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -6266,6 +6156,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6275,6 +6166,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6284,6 +6176,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -6337,19 +6230,23 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-negated-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha512-czXVVn/QEmgvej1f50BZ648vUI+em0xqMq2Sn+QncCLN4zj1UAxlT+kw/6ggQTOaZPd1HqKQGEqbpQVtJucWug==",
+		"node_modules/is-network-error": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+			"integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -6360,15 +6257,6 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6387,30 +6275,6 @@
 			"integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-relative": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-unc-path": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-unc-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-			"license": "MIT",
-			"dependencies": {
-				"unc-path-regex": "^0.1.2"
-			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6448,19 +6312,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-valid-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-			"integrity": "sha512-AhiROmoEFDSsjx8hW+5sGwgKVIORcXnrlAx/R0ZSeaPw70Vw0CqkGBBhHGL58Uox2eXnU1AnvXJl1XlyedO5bA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6483,16 +6339,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/jest-diff": {
 			"version": "30.1.2",
@@ -6810,42 +6658,6 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/last-run": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/last-run/-/last-run-2.0.0.tgz",
-			"integrity": "sha512-j+y6WhTLN4Itnf9j5ZQos1BGPCS8DAwmgMroR3OzfxAsBxam0hMw7J8M3KqZl0pLQJ1jNnwIexg5DYpC/ctwEQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/lead": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/lead/-/lead-4.0.0.tgz",
-			"integrity": "sha512-DpMa59o5uGUWWjruMp71e6knmwKU3jRBBn1kjuLWN9EeIOxNeSAwvHf03WIl8g/ZMR2oSQC9ej3yeLBwdDc/pg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/liftoff": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-5.0.1.tgz",
-			"integrity": "sha512-wwLXMbuxSF8gMvubFcFRp56lkFV69twvbU5vDPbaw+Q+/rF8j0HKjGbIdlSi+LuJm9jf7k9PB+nTxnsLMPcv2Q==",
-			"license": "MIT",
-			"dependencies": {
-				"extend": "^3.0.2",
-				"findup-sync": "^5.0.0",
-				"fined": "^2.0.0",
-				"flagged-respawn": "^2.0.0",
-				"is-plain-object": "^5.0.0",
-				"rechoir": "^0.8.0",
-				"resolve": "^1.20.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -7215,15 +7027,6 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
-		"node_modules/map-cache": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/mdn-data": {
 			"version": "2.12.2",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -7245,6 +7048,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -7258,6 +7062,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -7475,15 +7280,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/mute-stdout": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-2.0.0.tgz",
-			"integrity": "sha512-32GSKM3Wyc8dg/p39lWPKYu8zci9mJFzV1Np9Of0ZEpe6Fhssn/FbI7ywAMd40uX+p3ZKh3T5EeCFv81qS3HmQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -7541,27 +7337,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/now-and-later": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-3.0.0.tgz",
-			"integrity": "sha512-pGO4pzSdaxhWTGkfSfHx3hVzJVslFPwBp2Myq9MYN/ChfJZF87ochMAXnvz6/58RJSf5ik2q9tXprBBrk2cpcg==",
-			"license": "MIT",
-			"dependencies": {
-				"once": "^1.4.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
 		"node_modules/npm-run-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -7579,33 +7354,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/object.defaults": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
-			"integrity": "sha512-c/K0mw/F11k4dEUBMW8naXUuBuhxRCfG7W+yFy8EcijU/rSmazOUd1XAEEe6bC0OuXY4HUKjTJv7xbxIMqdxrA==",
-			"license": "MIT",
-			"dependencies": {
-				"array-each": "^1.0.1",
-				"array-slice": "^1.0.0",
-				"for-own": "^1.0.0",
-				"isobject": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object.pick": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ohash": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -7617,6 +7365,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -7680,6 +7429,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-retry": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.0.0.tgz",
+			"integrity": "sha512-3BgO9rjULJYyr0Y0pcsG7FZ+7JB/hfOODO8kx9ppumiO5jprUF92WK/Y7Q0xppZtq4VhTcPiVq7qWLQfIV5aKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-network-error": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7691,20 +7455,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse-filepath": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-			"integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
-			"license": "MIT",
-			"dependencies": {
-				"is-absolute": "^1.0.0",
-				"map-cache": "^0.2.0",
-				"path-root": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.8"
 			}
 		},
 		"node_modules/parse-json": {
@@ -7740,6 +7490,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7805,28 +7556,8 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/path-root": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-			"integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-			"license": "MIT",
-			"dependencies": {
-				"path-root-regex": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/path-root-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-			"integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -8176,9 +7907,31 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/react-redux": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/use-sync-external-store": "^0.0.6",
+				"use-sync-external-store": "^1.4.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.2.25 || ^19",
+				"react": "^18.0 || ^19",
+				"redux": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"redux": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/react-refresh": {
 			"version": "0.17.0",
@@ -8301,6 +8054,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -8315,6 +8069,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
 			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
@@ -8327,6 +8082,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -8335,16 +8091,31 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/rechoir": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
-			"integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+		"node_modules/recharts": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+			"integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
 			"license": "MIT",
 			"dependencies": {
-				"resolve": "^1.20.0"
+				"@reduxjs/toolkit": "1.x.x || 2.x.x",
+				"clsx": "^2.1.1",
+				"decimal.js-light": "^2.5.1",
+				"es-toolkit": "^1.39.3",
+				"eventemitter3": "^5.0.1",
+				"immer": "^10.1.1",
+				"react-redux": "8.x.x || 9.x.x",
+				"reselect": "5.1.1",
+				"tiny-invariant": "^1.3.3",
+				"use-sync-external-store": "^1.2.2",
+				"victory-vendor": "^37.0.2"
 			},
 			"engines": {
-				"node": ">= 10.13.0"
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/redent": {
@@ -8361,34 +8132,26 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-			"license": "ISC"
+		"node_modules/redux": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+			"license": "MIT"
 		},
-		"node_modules/replace-ext": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-			"integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+		"node_modules/redux-thunk": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
 			"license": "MIT",
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/replace-homedir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-2.0.0.tgz",
-			"integrity": "sha512-bgEuQQ/BHW0XkkJtawzrfzHFSN70f/3cNOiHa2QsYxqrjaC30X1k74FJ6xswVBP0sr0SpGIdVFuPwfrYziVeyw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
+			"peerDependencies": {
+				"redux": "^5.0.0"
 			}
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -8439,10 +8202,17 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/reselect": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"license": "MIT"
+		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
 			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.16.0",
@@ -8473,6 +8243,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
 			"integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"expand-tilde": "^2.0.0",
@@ -8490,18 +8261,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-options": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-2.0.0.tgz",
-			"integrity": "sha512-/FopbmmFOQCfsCx77BRFdKOniglTiHumLgwvd6IDPihy1GKkadZbgQJBcTb2lMzSR1pndzd96b1nZrreZ7+9/A==",
-			"license": "MIT",
-			"dependencies": {
-				"value-or-function": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -8522,6 +8281,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -8703,6 +8463,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8723,6 +8484,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sass-lookup": {
@@ -8775,7 +8537,7 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -8787,18 +8549,6 @@
 			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/semver-greatest-satisfied-range": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-2.0.0.tgz",
-			"integrity": "sha512-lH3f6kMbwyANB7HuOWRMlLCa2itaCrZJ+SAqqkSZrZKO/cAsk2EOyaKHUtNkVLFyFW9pct22SFesFp3Z7zpA0g==",
-			"license": "MIT",
-			"dependencies": {
-				"sver": "^1.8.3"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
 		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
@@ -8887,15 +8637,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/sparkles": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-2.1.0.tgz",
-			"integrity": "sha512-r7iW1bDw8R/cFifrD3JnQJX0K1jqT0kprL48BiBpLZLJPmAm34zsVBsK5lc7HirZYZqMW65dOXZgbAGt/I6frg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -8930,21 +8671,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/stream-composer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stream-composer/-/stream-composer-1.0.2.tgz",
-			"integrity": "sha512-bnBselmwfX5K10AH6L4c8+S5lgZMWI7ZYrz2rvYjCPB2DIMC4Ig8OpxGpNJSxRZ58oti7y1IcNvjBAz9vW5m4w==",
-			"license": "MIT",
-			"dependencies": {
-				"streamx": "^2.13.2"
-			}
-		},
-		"node_modules/stream-exhaust": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-			"integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
-			"license": "MIT"
-		},
 		"node_modules/stream-to-array": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
@@ -8955,21 +8681,11 @@
 				"any-promise": "^1.1.0"
 			}
 		},
-		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
-			"license": "MIT",
-			"dependencies": {
-				"events-universal": "^1.0.0",
-				"fast-fifo": "^1.3.2",
-				"text-decoder": "^1.1.0"
-			}
-		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
@@ -8979,6 +8695,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -9008,6 +8725,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -9099,6 +8817,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -9111,21 +8830,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/sver": {
-			"version": "1.8.4",
-			"resolved": "https://registry.npmjs.org/sver/-/sver-1.8.4.tgz",
-			"integrity": "sha512-71o1zfzyawLfIWBOmw8brleKyvnbn73oVHNCsu51uPMz/HWiKkkXsI31JjHW5zqXEqnPYkIiHd8ZmL7FCimLEA==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"semver": "^6.3.0"
 			}
 		},
 		"node_modules/svg-parser": {
@@ -9196,15 +8907,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/teex": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-			"license": "MIT",
-			"dependencies": {
-				"streamx": "^2.12.5"
-			}
-		},
 		"node_modules/terser": {
 			"version": "5.44.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
@@ -9231,20 +8933,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"b4a": "^1.6.4"
-			}
-		},
 		"node_modules/tiny-invariant": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
 			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tinybench": {
@@ -9332,24 +9024,13 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/to-through": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/to-through/-/to-through-3.0.0.tgz",
-			"integrity": "sha512-y8MN937s/HVhEoBU1SxfHC+wxCHkV1a9gW8eAdTadYh/bGyesZIVcbjI+mSpFbSVwQici/XjBjuUyri1dnXwBw==",
-			"license": "MIT",
-			"dependencies": {
-				"streamx": "^2.12.5"
-			},
-			"engines": {
-				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/totalist": {
@@ -9511,39 +9192,6 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/unc-path-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/undertaker": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/undertaker/-/undertaker-2.0.0.tgz",
-			"integrity": "sha512-tO/bf30wBbTsJ7go80j0RzA2rcwX6o7XPBpeFcb+jzoeb4pfMM2zUeSDIkY1AWqeZabWxaQZ/h8N9t35QKDLPQ==",
-			"license": "MIT",
-			"dependencies": {
-				"bach": "^2.0.1",
-				"fast-levenshtein": "^3.0.0",
-				"last-run": "^2.0.0",
-				"undertaker-registry": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/undertaker-registry": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-2.0.0.tgz",
-			"integrity": "sha512-+hhVICbnp+rlzZMgxXenpvTxpuvA67Bfgtt+O9WOE5jo7w/dyiF1VmoZVIHvP2EkUjsyKyTwYKlLhA+j47m1Ew==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
 		"node_modules/undici-types": {
 			"version": "7.12.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
@@ -9678,138 +9326,29 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/v8flags": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-4.0.1.tgz",
-			"integrity": "sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/value-or-function": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-4.0.0.tgz",
-			"integrity": "sha512-aeVK81SIuT6aMJfNo9Vte8Dw0/FZINGBV8BfCraGtqVxIeLAEhJyoWs8SmvRVmXfGss2PmmOwZCuBPbZR+IYWg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/vinyl": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
-			"integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
-			"license": "MIT",
+		"node_modules/victory-vendor": {
+			"version": "37.3.6",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+			"integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+			"license": "MIT AND ISC",
 			"dependencies": {
-				"clone": "^2.1.2",
-				"remove-trailing-separator": "^1.1.0",
-				"replace-ext": "^2.0.0",
-				"teex": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/vinyl-contents": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/vinyl-contents/-/vinyl-contents-2.0.0.tgz",
-			"integrity": "sha512-cHq6NnGyi2pZ7xwdHSW1v4Jfnho4TEGtxZHw01cmnc8+i7jgR6bRnED/LbrKan/Q7CvVLbnvA5OepnhbpjBZ5Q==",
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^5.0.0",
-				"vinyl": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/vinyl-contents/node_modules/bl": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-			"integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-			"license": "MIT",
-			"dependencies": {
-				"buffer": "^6.0.3",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
-		"node_modules/vinyl-contents/node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
-		},
-		"node_modules/vinyl-fs": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-4.0.2.tgz",
-			"integrity": "sha512-XRFwBLLTl8lRAOYiBqxY279wY46tVxLaRhSwo3GzKEuLz1giffsOquWWboD/haGf5lx+JyTigCFfe7DWHoARIA==",
-			"license": "MIT",
-			"dependencies": {
-				"fs-mkdirp-stream": "^2.0.1",
-				"glob-stream": "^8.0.3",
-				"graceful-fs": "^4.2.11",
-				"iconv-lite": "^0.6.3",
-				"is-valid-glob": "^1.0.0",
-				"lead": "^4.0.0",
-				"normalize-path": "3.0.0",
-				"resolve-options": "^2.0.0",
-				"stream-composer": "^1.0.2",
-				"streamx": "^2.14.0",
-				"to-through": "^3.0.0",
-				"value-or-function": "^4.0.0",
-				"vinyl": "^3.0.1",
-				"vinyl-sourcemap": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/vinyl-sourcemap": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-2.0.0.tgz",
-			"integrity": "sha512-BAEvWxbBUXvlNoFQVFVHpybBbjW1r03WhohJzJDSfgrrK5xVYIDTan6xN14DlyImShgDRv2gl9qhM6irVMsV0Q==",
-			"license": "MIT",
-			"dependencies": {
-				"convert-source-map": "^2.0.0",
-				"graceful-fs": "^4.2.10",
-				"now-and-later": "^3.0.0",
-				"streamx": "^2.12.5",
-				"vinyl": "^3.0.0",
-				"vinyl-contents": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/vinyl/node_modules/clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
 			}
 		},
 		"node_modules/vite": {
@@ -10304,6 +9843,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -10333,6 +9873,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -10350,6 +9891,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ws": {
@@ -10427,6 +9969,7 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -10443,6 +9986,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
 			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^7.0.2",
@@ -10461,6 +10005,7 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,13 @@
 		"@hookform/resolvers": "^5.2.2",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@tanstack/react-query": "^5.89.0",
+		"@tanstack/react-table": "^8.21.3",
+		"p-retry": "^7.0.0",
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1",
 		"react-hook-form": "^7.62.0",
 		"react-router-dom": "^7.9.1",
+		"recharts": "^3.2.1",
 		"use-sync-external-store": "^1.5.0",
 		"zod": "^4.1.8",
 		"zustand": "^5.0.8"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { ADS_DEBUG } from "virtual:ads-config";
+import { ADS_DEBUG, ENABLE_REPORTING } from "virtual:ads-config";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/store/auth";
 import Loader from "./Loader";
@@ -34,6 +34,13 @@ export default function Header() {
 								{adsBtnLabel}
 							</Link>
 						)}
+
+						{isLoggedIn && ENABLE_REPORTING && (
+							<Link to="/stats" className="btn-nav">
+								Stats
+							</Link>
+						)}
+
 						{isLoggedIn && (
 							<Link to="/ads/create" className="btn-nav">
 								Create ad

--- a/src/features/stats/StatsPage.tsx
+++ b/src/features/stats/StatsPage.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { ChartModal } from "./components/ChartModal";
+import { Controls } from "./components/Controls";
+import { MetricsChips } from "./components/MetricsChips";
+import { StatsTable } from "./components/StatsTable";
+import { METRICS } from "./constants/metrics";
+import { useColumns } from "./hooks/useColumns";
+import { useStatsQuery } from "./hooks/useStatsQuery";
+import type { MetricKey } from "./types";
+import { useSavedViews } from "./useSavedViews";
+
+function useTodayRange() {
+	const now = new Date();
+	const to = now.toISOString().slice(0, 10);
+	const from = new Date(now.getTime() - 1000 * 60 * 60 * 24 * 2)
+		.toISOString()
+		.slice(0, 10);
+	return { from, to };
+}
+
+export default function StatsPage() {
+	const { from: defFrom, to: defTo } = useTodayRange();
+	const [from, setFrom] = useState(defFrom);
+	const [to, setTo] = useState(defTo);
+	const [groupBy, setGroupBy] = useState("day,event,adapter");
+	const [selectedMetrics, setSelectedMetrics] = useState<MetricKey[]>([
+		"count",
+		"wins",
+		"cpmAvg",
+	]);
+	const [chartOpen, setChartOpen] = useState(false);
+
+	const { names, saveView, getView } = useSavedViews();
+	const [viewName, setViewName] = useState("");
+
+	const {
+		data = [],
+		isLoading,
+		error,
+	} = useStatsQuery({
+		from,
+		to,
+		groupBy,
+		metrics: selectedMetrics,
+	});
+
+	const { columns } = useColumns(selectedMetrics);
+
+	function toggleMetric(m: MetricKey) {
+		setSelectedMetrics((prev) =>
+			prev.includes(m) ? prev.filter((x) => x !== m) : [...prev, m],
+		);
+	}
+	function onSaveView() {
+		const name = viewName.trim() || "Default";
+		saveView({ name, metrics: selectedMetrics, groupBy });
+	}
+	function onLoadView(name: string) {
+		const v = getView(name);
+		if (!v) return;
+		setSelectedMetrics(v.metrics);
+		setGroupBy(v.groupBy);
+		setViewName(v.name);
+	}
+
+	return (
+		<div className="space-y-4">
+			<h1 className="text-2xl font-semibold">Ads Analytics</h1>
+
+			<Controls
+				from={from}
+				to={to}
+				groupBy={groupBy}
+				setFrom={setFrom}
+				setTo={setTo}
+				setGroupBy={setGroupBy}
+				viewName={viewName}
+				setViewName={setViewName}
+				names={names}
+				onSaveView={onSaveView}
+				onLoadView={onLoadView}
+				onOpenChart={() => setChartOpen(true)}
+			/>
+
+			<MetricsChips
+				all={METRICS}
+				selected={selectedMetrics}
+				toggle={toggleMetric}
+			/>
+
+			<StatsTable
+				data={data}
+				columns={columns}
+				selectedMetrics={selectedMetrics}
+				isLoading={isLoading}
+				error={error}
+			/>
+
+			<ChartModal
+				open={chartOpen}
+				onClose={() => setChartOpen(false)}
+				data={data}
+				metrics={selectedMetrics}
+				metricMeta={METRICS}
+			/>
+		</div>
+	);
+}

--- a/src/features/stats/api.ts
+++ b/src/features/stats/api.ts
@@ -1,0 +1,50 @@
+import { API_BASE } from "@/lib/apiBase";
+import { reportError } from "@/reporting/errors";
+import type { MetricKey, StatRow } from "./types";
+
+export interface StatsQuery {
+	from?: string; // YYYY-MM-DD
+	to?: string; // YYYY-MM-DD
+	groupBy?: string; // "day,event,adapter"
+	metrics?: MetricKey[]; // перелік метрик
+	limit?: number; // серверна пагінація (опціонально)
+	offset?: number; // серверна пагінація (опціонально)
+	event?: string; // фільтр за івентом
+	adapter?: string;
+	adUnitCode?: string;
+	creativeId?: string;
+}
+
+export async function fetchStats(q: StatsQuery): Promise<StatRow[]> {
+	const params = new URLSearchParams();
+	if (q.from) params.set("from", q.from);
+	if (q.to) params.set("to", q.to);
+	if (q.groupBy) params.set("groupBy", q.groupBy);
+	if (q.metrics?.length) params.set("metrics", q.metrics.join(","));
+	if (q.limit) params.set("limit", String(q.limit));
+	if (q.offset) params.set("offset", String(q.offset));
+	if (q.event) params.set("event", q.event);
+	if (q.adapter) params.set("adapter", q.adapter);
+	if (q.adUnitCode) params.set("adUnitCode", q.adUnitCode);
+	if (q.creativeId) params.set("creativeId", q.creativeId);
+
+	const url = `${API_BASE || ""}/api/stats?${params.toString()}`;
+
+	try {
+		const res = await fetch(url);
+		if (!res.ok) throw new Error(`GET ${url} -> ${res.status}`);
+
+		const ct = res.headers.get("content-type") || "";
+		if (!ct.includes("application/json")) {
+			const preview = (await res.text()).slice(0, 200);
+			throw new Error(
+				`Expected JSON, got "${ct}" [${res.status}] preview: ${preview}`,
+			);
+		}
+
+		return (await res.json()) as StatRow[];
+	} catch (err) {
+		reportError(err, { where: "fetchStats", url });
+		throw err;
+	}
+}

--- a/src/features/stats/components/ChartModal.tsx
+++ b/src/features/stats/components/ChartModal.tsx
@@ -1,0 +1,85 @@
+import { useId } from "react";
+import {
+	CartesianGrid,
+	Legend,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import type { MetricKey, StatRow } from "../types";
+
+export function ChartModal({
+	open,
+	onClose,
+	data,
+	metrics,
+	metricMeta,
+}: {
+	open: boolean;
+	onClose: () => void;
+	data: StatRow[];
+	metrics: MetricKey[];
+	metricMeta: Record<MetricKey, { label: string }>;
+}) {
+	const titleId = useId();
+	if (!open) return null;
+
+	return (
+		<div className="fixed inset-0 flex items-center justify-center p-4">
+			<button
+				type="button"
+				aria-label="Close chart modal"
+				className="absolute inset-0 bg-black/50"
+				onClick={onClose}
+				onKeyDown={(e) => {
+					if (e.key === "Escape" || e.key === "Enter" || e.key === " ")
+						onClose();
+				}}
+			/>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				className="relative bg-white dark:bg-gray-900 rounded-xl p-4 w-full max-w-5xl"
+				onClick={(e) => e.stopPropagation()}
+				onKeyDown={(e) => e.stopPropagation()}
+			>
+				<div className="flex items-center justify-between mb-3">
+					<h2 id={titleId} className="text-xl font-semibold">
+						Metrics Comparison
+					</h2>
+					<button
+						type="button"
+						className="px-3 py-1 rounded border"
+						onClick={onClose}
+					>
+						Close
+					</button>
+				</div>
+				<div className="h-[420px]">
+					<ResponsiveContainer width="100%" height="100%">
+						<LineChart data={data}>
+							<CartesianGrid strokeDasharray="3 3" />
+							<XAxis dataKey={(d: StatRow) => d.date ?? d.ts.slice(0, 10)} />
+							<YAxis />
+							<Tooltip />
+							<Legend />
+							{metrics.map((m) => (
+								<Line
+									key={m}
+									type="monotone"
+									dataKey={m}
+									name={metricMeta[m].label}
+									dot
+								/>
+							))}
+						</LineChart>
+					</ResponsiveContainer>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/features/stats/components/Controls.tsx
+++ b/src/features/stats/components/Controls.tsx
@@ -1,0 +1,106 @@
+export type ControlsProps = {
+	from: string;
+	to: string;
+	groupBy: string;
+	setFrom: (v: string) => void;
+	setTo: (v: string) => void;
+	setGroupBy: (v: string) => void;
+
+	viewName: string;
+	setViewName: (v: string) => void;
+	names: string[];
+	onSaveView: () => void;
+	onLoadView: (name: string) => void;
+
+	onOpenChart: () => void;
+};
+
+export function Controls(props: ControlsProps) {
+	const {
+		from,
+		to,
+		groupBy,
+		setFrom,
+		setTo,
+		setGroupBy,
+		viewName,
+		setViewName,
+		names,
+		onSaveView,
+		onLoadView,
+		onOpenChart,
+	} = props;
+
+	return (
+		<div className="flex flex-wrap items-end gap-3 p-3 rounded-xl border bg-white/60 dark:bg-white/5 shadow-sm backdrop-blur-sm">
+			<label className="flex flex-col">
+				<span className="text-xs text-gray-400">From</span>
+				<input
+					type="date"
+					value={from}
+					onChange={(e) => setFrom(e.target.value)}
+					className="border rounded p-2"
+				/>
+			</label>
+
+			<label className="flex flex-col">
+				<span className="text-xs text-gray-400">To</span>
+				<input
+					type="date"
+					value={to}
+					onChange={(e) => setTo(e.target.value)}
+					className="border rounded p-2"
+				/>
+			</label>
+
+			<label className="flex flex-col w-[320px]">
+				<span className="text-xs text-gray-400">Group by</span>
+				<input
+					value={groupBy}
+					onChange={(e) => setGroupBy(e.target.value)}
+					className="border rounded p-2"
+					placeholder="day,event,adapter"
+				/>
+			</label>
+
+			<div className="flex items-center gap-2 ml-auto">
+				<input
+					placeholder="view name"
+					className="border rounded p-2 w-40"
+					value={viewName}
+					onChange={(e) => setViewName(e.target.value)}
+				/>
+				<button
+					type="button"
+					onClick={onSaveView}
+					className="px-3 py-2 rounded bg-blue-600 text-white"
+				>
+					Save View
+				</button>
+
+				<select
+					className="border rounded p-2"
+					onChange={(e) => onLoadView(e.target.value)}
+					value=""
+				>
+					<option value="" disabled>
+						Select View
+					</option>
+					{names.map((n) => (
+						<option key={n} value={n}>
+							{n}
+						</option>
+					))}
+				</select>
+
+				<button
+					type="button"
+					onClick={onOpenChart}
+					className="px-3 py-2 rounded border"
+				>
+					Compare (Chart)
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/features/stats/components/MetricsChips.tsx
+++ b/src/features/stats/components/MetricsChips.tsx
@@ -1,0 +1,31 @@
+import type { MetricKey } from "../types";
+
+export function MetricsChips({
+	all,
+	selected,
+	toggle,
+}: {
+	all: Record<MetricKey, { label: string }>;
+	selected: MetricKey[];
+	toggle: (m: MetricKey) => void;
+}) {
+	return (
+		<div className="flex flex-wrap gap-2">
+			{(Object.keys(all) as MetricKey[]).map((m) => {
+				const active = selected.includes(m);
+				return (
+					<button
+						type="button"
+						key={m}
+						onClick={() => toggle(m)}
+						className={`px-3 py-1 rounded-full text-sm border ${
+							active ? "bg-blue-600 text-white" : "bg-gray-100 dark:bg-gray-800"
+						}`}
+					>
+						{all[m].label}
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/features/stats/components/StatsTable.tsx
+++ b/src/features/stats/components/StatsTable.tsx
@@ -1,0 +1,200 @@
+import {
+	type ColumnDef,
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getSortedRowModel,
+	useReactTable,
+} from "@tanstack/react-table";
+import type React from "react";
+import { useMemo } from "react";
+import type { MetricKey, StatRow } from "../types";
+
+type Props = {
+	data: StatRow[];
+	columns: ColumnDef<StatRow, unknown>[];
+	selectedMetrics: MetricKey[];
+	isLoading?: boolean;
+	error?: unknown;
+};
+
+type MaybeId = { id?: unknown };
+type MaybeAccessorKey = { accessorKey?: string | number | symbol };
+
+function getColId(c: ColumnDef<StatRow, unknown>, index: number): string {
+	const id = (c as MaybeId).id;
+	if (typeof id === "string" && id) return id;
+
+	const ak = (c as MaybeAccessorKey).accessorKey;
+	if (
+		typeof ak === "string" ||
+		typeof ak === "number" ||
+		typeof ak === "symbol"
+	) {
+		return String(ak);
+	}
+
+	return `col-${index}`;
+}
+
+function errMessage(err: unknown): string {
+	if (err && typeof err === "object" && "message" in err) {
+		const m = (err as { message?: unknown }).message;
+		if (typeof m === "string") return m;
+	}
+	try {
+		return JSON.stringify(err);
+	} catch {
+		return String(err);
+	}
+}
+
+export function StatsTable({
+	data,
+	columns,
+	selectedMetrics,
+	isLoading,
+	error,
+}: Props) {
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+	});
+
+	const metricIds = useMemo(
+		() => new Set<string>(selectedMetrics as unknown as string[]),
+		[selectedMetrics],
+	);
+
+	const widthById: Record<string, string> = {
+		date: "9rem",
+		hour: "6rem",
+		event: "10rem",
+		adapter: "10rem",
+		adUnitCode: "10rem",
+		creativeId: "9rem",
+	};
+
+	return (
+		<div className="overflow-x-auto rounded-xl border bg-white/60 dark:bg-white/5 shadow-sm backdrop-blur-sm">
+			<table className="min-w-full table-fixed border-separate border-spacing-0 text-sm">
+				<colgroup>
+					{columns.map((c, i) => {
+						const id = getColId(c, i);
+						const w = widthById[id];
+						return <col key={id} style={w ? { width: w } : undefined} />;
+					})}
+				</colgroup>
+
+				<thead className="bg-gray-50/80 dark:bg-gray-900/80 sticky top-0 z-10">
+					{table.getHeaderGroups().map((hg) => (
+						<tr key={hg.id}>
+							{hg.headers.map((h) => {
+								const canSort = h.column.getCanSort();
+								const sortHandler = h.column.getToggleSortingHandler();
+								const sort = h.column.getIsSorted();
+
+								return (
+									<th
+										key={h.id}
+										aria-sort={
+											sort === "asc"
+												? "ascending"
+												: sort === "desc"
+													? "descending"
+													: "none"
+										}
+										className="p-2 text-left border-b text-[12px] font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300 bg-white/80 dark:bg-gray-900/80 sticky top-0"
+									>
+										<button
+											type="button"
+											className="cursor-pointer select-none flex items-center gap-1 disabled:opacity-50"
+											onClick={canSort && sortHandler ? sortHandler : undefined}
+											onKeyDown={(e) => {
+												if (!canSort || !sortHandler) return;
+												if (e.key === "Enter" || e.key === " ") {
+													e.preventDefault();
+													sortHandler(e as unknown as React.MouseEvent);
+												}
+											}}
+											aria-label="Sort column"
+											disabled={!canSort}
+										>
+											{flexRender(h.column.columnDef.header, h.getContext())}
+											{
+												({ asc: "↑", desc: "↓", false: "" } as const)[
+													String(sort || "false") as "asc" | "desc" | "false"
+												]
+											}
+										</button>
+
+										{h.column.getCanFilter() && (
+											<input
+												className="mt-1 w-full h-8 rounded-md border px-2 text-xs placeholder:text-gray-400 dark:bg-transparent"
+												placeholder="Filter…"
+												aria-label={`Filter ${String(
+													h.column.columnDef.header ?? h.column.id,
+												)}`}
+												value={(h.column.getFilterValue() as string) ?? ""}
+												onChange={(e) =>
+													h.column.setFilterValue(e.target.value)
+												}
+											/>
+										)}
+									</th>
+								);
+							})}
+						</tr>
+					))}
+				</thead>
+
+				<tbody>
+					{isLoading ? (
+						<tr>
+							<td className="p-4" colSpan={columns.length}>
+								Loading…
+							</td>
+						</tr>
+					) : error ? (
+						<tr>
+							<td className="p-4 text-red-600" colSpan={columns.length}>
+								{errMessage(error)}
+							</td>
+						</tr>
+					) : table.getRowModel().rows.length === 0 ? (
+						<tr>
+							<td className="p-4" colSpan={columns.length}>
+								No data
+							</td>
+						</tr>
+					) : (
+						table.getRowModel().rows.map((row) => (
+							<tr
+								key={row.id}
+								className="border-t odd:bg-gray-50/50 dark:odd:bg-white/5 hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+							>
+								{row.getVisibleCells().map((cell) => {
+									const isMetric = metricIds.has(cell.column.id);
+									return (
+										<td
+											key={cell.id}
+											className={`p-2 align-top ${isMetric ? "text-right tabular-nums" : ""}`}
+										>
+											{flexRender(
+												cell.column.columnDef.cell,
+												cell.getContext(),
+											)}
+										</td>
+									);
+								})}
+							</tr>
+						))
+					)}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/src/features/stats/constants/metrics.ts
+++ b/src/features/stats/constants/metrics.ts
@@ -1,0 +1,19 @@
+import type { MetricKey } from "../types";
+
+export const METRICS: Record<
+	MetricKey,
+	{ label: string; fmt?: (n: number | undefined) => string }
+> = {
+	count: { label: "Events", fmt: (n) => (n ?? 0).toLocaleString() },
+	requests: { label: "Requests", fmt: (n) => (n ?? 0).toLocaleString() },
+	responses: { label: "Responses", fmt: (n) => (n ?? 0).toLocaleString() },
+	wins: { label: "Wins", fmt: (n) => (n ?? 0).toLocaleString() },
+	cpmAvg: { label: "eCPM avg", fmt: (n) => (n ?? 0).toFixed(2) },
+	cpmP95: { label: "eCPM p95", fmt: (n) => (n ?? 0).toFixed(2) },
+	ctr: { label: "CTR", fmt: (n) => `${Math.round((n ?? 0) * 10000) / 100}%` },
+	revenue: {
+		label: "Revenue",
+		fmt: (n) =>
+			`$${(n ?? 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}`,
+	},
+};

--- a/src/features/stats/hooks/useColumns.tsx
+++ b/src/features/stats/hooks/useColumns.tsx
@@ -1,0 +1,52 @@
+import { type ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { METRICS } from "../constants/metrics";
+import type { MetricKey, StatRow } from "../types";
+
+const column = createColumnHelper<StatRow>();
+
+export function useColumns(selectedMetrics: MetricKey[]) {
+	const metricColumns = selectedMetrics.map((m) =>
+		column.accessor((row) => (row[m] ?? null) as number | null, {
+			id: m,
+			header: METRICS[m].label,
+			cell: (info) => {
+				const raw = info.getValue() ?? undefined;
+				const fmt = METRICS[m].fmt;
+				return (
+					<span className="tabular-nums">
+						{fmt ? fmt(raw) : String(raw ?? "")}
+					</span>
+				);
+			},
+		}),
+	);
+
+	const baseColumns = [
+		column.accessor((r) => r.date ?? r.ts.slice(0, 10), {
+			id: "date",
+			header: "Date",
+			cell: (info) => (
+				<span className="font-mono">{info.getValue<string>()}</span>
+			),
+		}),
+		column.accessor("hour", { header: "Hour" }),
+		column.accessor("event", { header: "Event" }),
+		column.accessor("adapter", { header: "Adapter" }),
+		column.accessor("adUnitCode", { header: "AdUnit" }),
+		column.accessor((r) => String(r.creativeId ?? ""), {
+			id: "creativeId",
+			header: "Creative",
+		}),
+	];
+
+	const columns = [...baseColumns, ...metricColumns] as unknown as ColumnDef<
+		StatRow,
+		unknown
+	>[];
+
+	return {
+		columns,
+		baseColumns: baseColumns as unknown as ColumnDef<StatRow, unknown>[],
+		metricColumns: metricColumns as unknown as ColumnDef<StatRow, unknown>[],
+	};
+}

--- a/src/features/stats/hooks/useStatsQuery.ts
+++ b/src/features/stats/hooks/useStatsQuery.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchStats } from "../api";
+import type { MetricKey, StatRow } from "../types";
+
+export function useStatsQuery(q: {
+	from: string;
+	to: string;
+	groupBy: string;
+	metrics: MetricKey[];
+}) {
+	return useQuery<StatRow[]>({
+		queryKey: ["stats", q],
+		queryFn: () => fetchStats(q),
+		staleTime: 30_000,
+	});
+}

--- a/src/features/stats/types.ts
+++ b/src/features/stats/types.ts
@@ -1,0 +1,28 @@
+export type MetricKey =
+	| "count"
+	| "requests"
+	| "responses"
+	| "wins"
+	| "cpmAvg"
+	| "cpmP95"
+	| "ctr"
+	| "revenue";
+
+export interface StatRow {
+	ts: string; // ISO початок бакета (година/день)
+	date?: string;
+	hour?: string; // "13:00"
+	event?: string;
+	adapter?: string;
+	adUnitCode?: string;
+	creativeId?: string | number | null;
+
+	count?: number;
+	requests?: number;
+	responses?: number;
+	wins?: number;
+	cpmAvg?: number;
+	cpmP95?: number;
+	ctr?: number; // 0..1
+	revenue?: number; // USD
+}

--- a/src/features/stats/useSavedViews.ts
+++ b/src/features/stats/useSavedViews.ts
@@ -1,0 +1,44 @@
+import { useMemo, useState } from "react";
+import type { MetricKey } from "./types";
+
+export interface SavedView {
+	name: string;
+	metrics: MetricKey[];
+	groupBy: string;
+}
+
+const LS_KEY = "stats_views";
+
+function readViews(): SavedView[] {
+	try {
+		const raw = localStorage.getItem(LS_KEY);
+		if (!raw) return [];
+		const arr = JSON.parse(raw) as SavedView[];
+		return Array.isArray(arr) ? arr : [];
+	} catch {
+		return [];
+	}
+}
+
+export function useSavedViews() {
+	const [views, setViews] = useState<SavedView[]>(() => readViews());
+	const names = useMemo(() => views.map((v) => v.name), [views]);
+
+	function saveView(view: SavedView) {
+		const next = [...views.filter((v) => v.name !== view.name), view];
+		setViews(next);
+		localStorage.setItem(LS_KEY, JSON.stringify(next));
+	}
+
+	function deleteView(name: string) {
+		const next = views.filter((v) => v.name !== name);
+		setViews(next);
+		localStorage.setItem(LS_KEY, JSON.stringify(next));
+	}
+
+	function getView(name: string) {
+		return views.find((v) => v.name === name);
+	}
+
+	return { views, names, saveView, deleteView, getView };
+}

--- a/src/lib/ads/prebidAnalytics.ts
+++ b/src/lib/ads/prebidAnalytics.ts
@@ -1,0 +1,150 @@
+import type {
+	AuctionInitData,
+	BidRequestedData,
+	BidResponseData,
+	BidWonData,
+} from "../analytics/events";
+import { report } from "../analytics/reporter";
+
+// ---- minimal pbjs typings ----
+type Size = [number, number];
+
+interface PbAdUnit {
+	code?: string;
+	mediaTypes?: { banner?: { sizes?: Size[] } };
+	sizes?: Size[];
+}
+
+interface PbAuctionInit {
+	auctionId?: string;
+	adUnits?: PbAdUnit[];
+}
+interface PbAuctionEnd {
+	auctionId?: string;
+}
+interface PbBidRequested {
+	auctionId?: string;
+	bidder?: string;
+	bidderCode?: string;
+	adUnitCode?: string;
+	sizes?: Size[];
+	mediaTypes?: { banner?: { sizes?: Size[] } };
+}
+interface PbBidResponse {
+	auctionId?: string;
+	bidder?: string;
+	bidderCode?: string;
+	adUnitCode?: string;
+	cpm?: number;
+	currency?: string;
+	cur?: string;
+	creativeId?: string | number;
+	width?: number;
+	w?: number;
+	height?: number;
+	h?: number;
+	timeToRespond?: number;
+	meta?: { advertiserDomains?: string[] };
+	adomain?: string[];
+}
+type PbBidWon = PbBidResponse;
+
+type PbEventName =
+	| "auctionInit"
+	| "auctionEnd"
+	| "bidRequested"
+	| "bidResponse"
+	| "bidWon";
+type PbEventMap = {
+	auctionInit: PbAuctionInit;
+	auctionEnd: PbAuctionEnd;
+	bidRequested: PbBidRequested;
+	bidResponse: PbBidResponse;
+	bidWon: PbBidWon;
+};
+
+interface Pbjs {
+	version?: string;
+	onEvent?<K extends PbEventName>(
+		name: K,
+		cb: (p: PbEventMap[K]) => void,
+	): void;
+	que?: Array<() => void>;
+}
+
+function isPbjs(v: unknown): v is Required<Pick<Pbjs, "onEvent">> & Pbjs {
+	return !!v && typeof (v as Record<string, unknown>).onEvent === "function";
+}
+
+// ---- pickers ----
+const pickAuctionInit = (p: PbAuctionInit): AuctionInitData => ({
+	auctionId: String(p?.auctionId ?? ""),
+	adUnits: (p?.adUnits ?? []).map((u) => ({
+		code: String(u?.code ?? ""),
+		sizes: u?.mediaTypes?.banner?.sizes ?? u?.sizes ?? undefined,
+	})),
+});
+
+const pickBidRequested = (p: PbBidRequested): BidRequestedData => ({
+	auctionId: p?.auctionId,
+	bidder: String(p?.bidder ?? p?.bidderCode ?? ""),
+	adUnitCode: String(p?.adUnitCode ?? ""),
+	sizes: p?.sizes ?? p?.mediaTypes?.banner?.sizes ?? undefined,
+});
+
+const pickBidResponse = (p: PbBidResponse): BidResponseData => ({
+	auctionId: p?.auctionId,
+	bidder: String(p?.bidder ?? p?.bidderCode ?? ""),
+	adUnitCode: String(p?.adUnitCode ?? ""),
+	cpm: typeof p?.cpm === "number" ? p.cpm : undefined,
+	cur: p?.currency || p?.cur,
+	creativeId: p?.creativeId,
+	w: p?.width ?? p?.w,
+	h: p?.height ?? p?.h,
+	timeToRespond: p?.timeToRespond,
+	adomain: p?.meta?.advertiserDomains ?? p?.adomain,
+});
+
+const pickBidWon = (p: PbBidWon): BidWonData => ({
+	auctionId: p?.auctionId,
+	bidder: String(p?.bidder ?? p?.bidderCode ?? ""),
+	adUnitCode: String(p?.adUnitCode ?? ""),
+	cpm: typeof p?.cpm === "number" ? p.cpm : undefined,
+	cur: p?.currency || p?.cur,
+	creativeId: p?.creativeId,
+});
+
+// ---- main ----
+export function attachPrebidAnalytics() {
+	const win = window as unknown as { pbjs?: Partial<Pbjs> };
+
+	const ready = () => {
+		const pb = win.pbjs;
+		if (!isPbjs(pb)) return;
+
+		report("adModuleLoad", { module: "prebid", version: pb.version });
+
+		pb.onEvent?.("auctionInit", (p) =>
+			report("auctionInit", pickAuctionInit(p)),
+		);
+		pb.onEvent?.("auctionEnd", (p) =>
+			report("auctionEnd", { auctionId: p?.auctionId }),
+		);
+		pb.onEvent?.("bidRequested", (p) =>
+			report("bidRequested", pickBidRequested(p)),
+		);
+		pb.onEvent?.("bidResponse", (p) =>
+			report("bidResponse", pickBidResponse(p)),
+		);
+		pb.onEvent?.("bidWon", (p) => report("bidWon", pickBidWon(p)));
+	};
+
+	if (isPbjs(win.pbjs)) {
+		ready();
+	} else {
+		const obj: Partial<Pbjs> = win.pbjs ?? {};
+		obj.que = obj.que ?? [];
+		obj.que.push(ready);
+		win.pbjs = obj;
+	}
+}

--- a/src/lib/ads/uid.ts
+++ b/src/lib/ads/uid.ts
@@ -1,12 +1,21 @@
+import { reportError } from "@/reporting/errors";
+
 export function ensureAdUid(): string {
-	const LS = "ad_uid";
-	let uid = localStorage.getItem(LS);
-
-	if (!uid) {
-		uid = Math.random().toString(36).slice(2) + Date.now().toString(36);
-		localStorage.setItem(LS, uid);
+	const KEY = "ad_uid";
+	try {
+		const existing = localStorage.getItem(KEY);
+		if (existing) {
+			window.__ads = { ...(window.__ads ?? {}), uid: existing };
+			return existing;
+		}
+		const uid = Math.random().toString(36).slice(2) + Date.now().toString(36);
+		localStorage.setItem(KEY, uid);
+		window.__ads = { ...(window.__ads ?? {}), uid };
+		return uid;
+	} catch (err) {
+		const fallback = `mem_${Math.random().toString(36).slice(2)}`;
+		reportError(err, { where: "ensureAdUid", fallback });
+		window.__ads = { ...(window.__ads ?? {}), uid: fallback };
+		return fallback;
 	}
-
-	window.__ads = { ...(window.__ads ?? {}), uid };
-	return uid;
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,52 @@
+export type EventName =
+	| "pageLoad"
+	| "adModuleLoad"
+	| "auctionInit"
+	| "auctionEnd"
+	| "bidRequested"
+	| "bidResponse"
+	| "bidWon";
+
+export interface BaseEvent {
+	event: EventName;
+	ts: number;
+	page: string;
+	ref?: string;
+	sid: string;
+	uid?: string;
+	data?: unknown;
+}
+
+export interface AuctionInitData {
+	auctionId: string;
+	adUnits: Array<{ code: string; sizes?: number[][] }>;
+}
+
+export interface BidRequestedData {
+	auctionId?: string;
+	bidder: string;
+	adUnitCode: string;
+	sizes?: number[][];
+}
+
+export interface BidResponseData {
+	auctionId?: string;
+	bidder: string;
+	adUnitCode: string;
+	cpm?: number;
+	cur?: string;
+	creativeId?: string | number;
+	w?: number;
+	h?: number;
+	timeToRespond?: number;
+	adomain?: string[];
+}
+
+export interface BidWonData {
+	auctionId?: string;
+	bidder: string;
+	adUnitCode: string;
+	cpm?: number;
+	cur?: string;
+	creativeId?: string | number;
+}

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,0 +1,4 @@
+export { attachPrebidAnalytics } from "@/lib/ads/prebidAnalytics";
+export * from "./events";
+export { enqueue, getSid } from "./queue";
+export { report } from "./reporter";

--- a/src/lib/analytics/queue.ts
+++ b/src/lib/analytics/queue.ts
@@ -1,0 +1,59 @@
+import { sendAnalyticsBatch } from "@/reporting/client-analytics";
+import type { BaseEvent } from "./events";
+
+const BATCH = Number(import.meta.env.VITE_REPORTING_BATCH ?? 20);
+const INTERVAL = Number(import.meta.env.VITE_REPORTING_INTERVAL ?? 2);
+const ENABLED =
+	String(import.meta.env.VITE_ENABLE_REPORTING ?? "false") === "true";
+
+export function getSid(): string {
+	const KEY = "sid";
+	try {
+		let sid = localStorage.getItem(KEY);
+		if (!sid) {
+			sid = Math.random().toString(36).slice(2) + Date.now().toString(36);
+			localStorage.setItem(KEY, sid);
+		}
+		return sid;
+	} catch {
+		return `mem_${Math.random().toString(36).slice(2)}`;
+	}
+}
+
+let queue: BaseEvent[] = [];
+let timer: number | undefined;
+
+async function flush(opts?: { unloading?: boolean }) {
+	if (!ENABLED || queue.length === 0) return;
+	const copy = queue;
+	queue = [];
+	try {
+		await sendAnalyticsBatch(copy, opts);
+	} catch (err) {
+		const { reportError } = await import("@/reporting/errors");
+		reportError(err, { where: "analytics:flush", batchSize: copy.length });
+	}
+}
+
+function schedule() {
+	if (timer) return;
+	timer = window.setTimeout(() => {
+		timer = undefined;
+		void flush();
+	}, INTERVAL * 1000) as unknown as number;
+}
+
+export function enqueue(ev: BaseEvent) {
+	if (!ENABLED) return;
+	queue.push(ev);
+	if (queue.length >= BATCH) void flush();
+	else schedule();
+}
+
+function flushOnUnload() {
+	void flush({ unloading: true });
+}
+window.addEventListener("pagehide", flushOnUnload);
+document.addEventListener("visibilitychange", () => {
+	if (document.visibilityState === "hidden") flushOnUnload();
+});

--- a/src/lib/analytics/reporter.ts
+++ b/src/lib/analytics/reporter.ts
@@ -1,0 +1,23 @@
+import type { BaseEvent, EventName } from "./events";
+import { enqueue, getSid } from "./queue";
+
+export interface ReporterContext {
+	uid?: string;
+}
+
+export function report(
+	event: EventName,
+	data?: unknown,
+	ctx?: ReporterContext,
+) {
+	const payload: BaseEvent = {
+		event,
+		ts: Date.now(),
+		page: location.href,
+		ref: document.referrer || undefined,
+		sid: getSid(),
+		uid: ctx?.uid,
+		data,
+	};
+	enqueue(payload);
+}

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -1,0 +1,26 @@
+import pRetry, { type Options as RetryOptions } from "p-retry";
+
+export async function retry<T>(
+	runAttempt: (attempt: number) => Promise<T>,
+	options: RetryOptions = {},
+): Promise<T> {
+	return pRetry(runAttempt, {
+		retries: 3,
+		factor: 2,
+		minTimeout: 300,
+		maxTimeout: 2000,
+		...options,
+	});
+}
+
+export async function retryEach<T>(
+	tasks: Array<() => Promise<T>>,
+	options?: RetryOptions,
+): Promise<T[]> {
+	const results: T[] = [];
+	for (const task of tasks) {
+		const value = await retry(() => task(), options);
+		results.push(value);
+	}
+	return results;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,30 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./tailwind.css";
+import { initAnalytics } from "virtual:ads-analytics";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ensureAdUid } from "@/lib/ads/uid";
+import { report } from "@/lib/analytics/reporter";
+import { reportError } from "@/reporting/errors";
 import App from "./App";
 import { queryClient } from "./lib/query";
 import { ErrorBoundary } from "./reporting/ErrorBoundary";
 
+if (import.meta.env.VITE_ENABLE_REPORTING === "true") {
+	void initAnalytics({ enabled: true, context: { app: "news-app" } });
+}
+
+report("pageLoad");
 ensureAdUid();
 
-import("virtual:ads-module").then((m) => m.initAds?.()).catch(() => {});
+(async () => {
+	try {
+		const m = await import("virtual:ads-module");
+		if (typeof m.initAds === "function") await m.initAds();
+	} catch (err) {
+		reportError(err, { where: "bootstrap:ads-module" });
+	}
+})();
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("Root #root not found");

--- a/src/reporting/client-analytics.ts
+++ b/src/reporting/client-analytics.ts
@@ -1,6 +1,31 @@
-export function boot() {
-	// підключення аналітики
-	// ...
-	console.log("[analytics] booted");
+import type { BaseEvent } from "@/lib/analytics/events";
+
+export const ANALYTICS_ENDPOINT = String(
+	import.meta.env.VITE_REPORTING_URL || "/api/report",
+);
+
+export async function sendAnalyticsBatch(
+	events: BaseEvent[],
+	opts?: { unloading?: boolean },
+): Promise<void> {
+	if (!events.length) return;
+
+	const body = JSON.stringify(events);
+
+	if (opts?.unloading && "sendBeacon" in navigator) {
+		try {
+			navigator.sendBeacon(
+				ANALYTICS_ENDPOINT,
+				new Blob([body], { type: "application/json" }),
+			);
+			return;
+		} catch {}
+	}
+
+	await fetch(ANALYTICS_ENDPOINT, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body,
+		keepalive: !!opts?.unloading,
+	});
 }
-boot();

--- a/src/reporting/errors.ts
+++ b/src/reporting/errors.ts
@@ -1,3 +1,59 @@
-export function reportError(err: unknown, meta?: Record<string, unknown>) {
-	console.error("[reportError]", err, meta);
+type Extra = Record<string, unknown>;
+
+const LOG_ENDPOINT = import.meta.env.VITE_LOG_URL || "/api/report";
+
+export function reportError(err: unknown, extra: Extra = {}): void {
+	const payload =
+		err instanceof Error
+			? { name: err.name, message: err.message, stack: err.stack }
+			: { name: "UnknownError", message: String(err) };
+
+	console.error("[app:error]", { ...payload, ...extra });
+
+	const body = JSON.stringify({
+		...payload,
+		...extra,
+		ts: Date.now(),
+		url: location.href,
+	});
+
+	try {
+		if ("sendBeacon" in navigator) {
+			navigator.sendBeacon(
+				LOG_ENDPOINT,
+				new Blob([body], { type: "application/json" }),
+			);
+			return;
+		}
+	} catch {
+		/* fallthrough */
+	}
+
+	void fetch(LOG_ENDPOINT, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body,
+		keepalive: true,
+	}).catch(() => {});
+}
+
+export async function tryOrThrow<T>(
+	label: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	try {
+		return await fn();
+	} catch (err) {
+		reportError(err, { where: label });
+		throw err;
+	}
+}
+
+export function trySyncOrThrow<T>(label: string, fn: () => T): T {
+	try {
+		return fn();
+	} catch (err) {
+		reportError(err, { where: label });
+		throw err;
+	}
 }

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -9,6 +9,7 @@ import {
 
 import Layout from "@/components/Layout";
 import Loader from "@/components/Loader";
+import StatsPage from "@/features/stats/StatsPage";
 import { useAuth } from "@/store/auth";
 
 const Feed = lazy(() => import("@/features/news/Feed"));
@@ -83,12 +84,20 @@ const routes = [
 				),
 			},
 
-			// ads
 			{
 				path: "ads/create",
 				element: (
 					<RequireAuth>
 						<CreateAdShadow />
+					</RequireAuth>
+				),
+			},
+
+			{
+				path: "stats",
+				element: (
+					<RequireAuth>
+						<StatsPage />
 					</RequireAuth>
 				),
 			},

--- a/src/types/virtual-ads-analytics.d.ts
+++ b/src/types/virtual-ads-analytics.d.ts
@@ -1,21 +1,20 @@
 declare module "virtual:ads-analytics" {
-	export type AnalyticsContext = Record<string, unknown>;
-
-	export interface InitAnalyticsOptions {
+	export type AnalyticsInitOptions = {
 		enabled?: boolean;
-		context?: AnalyticsContext;
-		flushOnUnload?: boolean;
-	}
-
+		context?: Record<string, unknown>;
+	};
 	export function initAnalytics(
-		options?: InitAnalyticsOptions,
+		options?: AnalyticsInitOptions,
 	): void | Promise<void>;
-
-	export function track(event: string, payload?: Record<string, unknown>): void;
 }
 
 declare module "virtual:ads-module" {
 	export function initAds(): Promise<void> | void;
 	export function requestAndDisplay(adUnits?: unknown): Promise<void> | void;
 	export function refreshAds(codes?: string[]): Promise<void> | void;
+}
+
+declare module "virtual:ads-config" {
+	export const ENABLE_REPORTING: boolean;
+	export const ADS_MODE: "prebid" | "google" | string;
 }

--- a/src/types/virtual-ads-config.d.ts
+++ b/src/types/virtual-ads-config.d.ts
@@ -6,4 +6,5 @@ declare module "virtual:ads-config" {
 	export const BIDMATIC_SOURCE: number;
 	export const BIDMATIC_SPN: string | "";
 	export const GAM_NETWORK_CALLS: boolean;
+	export const ENABLE_REPORTING: boolean;
 }

--- a/src/types/virtual-ads.d.ts
+++ b/src/types/virtual-ads.d.ts
@@ -1,0 +1,11 @@
+declare module "virtual:ads-analytics" {
+	export function initAnalytics(options?: {
+		enabled?: boolean;
+		context?: Record<string, unknown>;
+	}): void;
+}
+declare module "virtual:ads-module" {
+	export function initAds(): Promise<void> | void;
+	export function requestAndDisplay(adUnits?: unknown): Promise<void> | void;
+	export function refreshAds(codes?: string[]): Promise<void> | void;
+}


### PR DESCRIPTION
…ivery, slices, export)    Module 1 – Analytics client
Implement modules/analytics.module.js with initAnalytics(options).
Captures events: page load, ad module load, auctionInit, auctionEnd, bidRequested, bidResponse, bidWon.
Data sent to backend per event: ts, uid, sid, page, ref, lang, tz, adapter, adUnitCode, bidder, creativeId, cpm, adomain[], wins.
Reliable background delivery:
In-memory queue + timed flush.
navigator.sendBeacon first; fallback to fetch(..., { keepalive: true }).
Batch splitting by count and ~60KB soft size; exponential backoff on failures.
Triggers on pagehide, visibilitychange(hidden), beforeunload, online.
Prebid integration: auto-hooks via pbjs.onEvent (if present) to emit all auction/bid events.
Public API for ad module: window.__analytics.{adModuleLoad,auctionInit,auctionEnd,bidRequested,bidResponse,bidWon}.
Toggleable same as ad module:
Vite virtual plugin virtual:ads-analytics + VITE_ENABLE_REPORTING=true.
Virtual loader throws readable error if file missing.
Type-safe, no any; small helpers for UID/SID; context propagation to every event.
Module 2 – Stats page (grid)
New grid built on TanStack Table for analytics:
Selectable slices: day, hour, event, adapter, adUnitCode, bidder, creativeId.
Selectable metrics: count, requests, responses, wins, cpmAvg, cpmP95, revenue.
Client-side sorting, filtering, right-aligned numeric cells, sensible column widths.
Pagination wired to backend limit/offset.
Export to CSV/XLSX via query param ?format=....