### PR TITLE
fix: improve error handling in CopyButton, ErrorBoundary, AdSlot

### DIFF
--- a/src/components/ads/AdSlot.tsx
+++ b/src/components/ads/AdSlot.tsx
@@ -216,8 +216,8 @@ export default function AdSlot({
 							endpoint: ep,
 						});
 						if (bid) mod.renderBidInto(el, bid, { endpoint: ep });
-					} catch {
-						/* ignore */
+					} catch (e) {
+						console.error("[AdSlot] fallback bid failed:", e);
 					}
 				}
 			}, fallbackMs) as unknown as number;

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -11,20 +11,24 @@ export default function CopyButton({
 	onCopied?: () => void;
 }) {
 	const [copied, setCopied] = useState(false);
+	const [failed, setFailed] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setFailed(false);
+			onCopied?.();
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			setFailed(true);
+			setTimeout(() => setFailed(false), 2000);
+		}
+	};
+
 	return (
-		<Button
-			className={className}
-			onClick={async () => {
-				try {
-					await navigator.clipboard.writeText(text);
-					setCopied(true);
-					onCopied?.();
-					setTimeout(() => setCopied(false), 1500);
-				} catch {}
-			}}
-			aria-live="polite"
-		>
-			{copied ? "Copied!" : "Copy"}
+		<Button className={className} onClick={handleCopy} aria-live="polite">
+			{failed ? "Failed to copy" : copied ? "Copied!" : "Copy"}
 		</Button>
 	);
 }

--- a/src/reporting/ErrorBoundary.tsx
+++ b/src/reporting/ErrorBoundary.tsx
@@ -1,11 +1,19 @@
 import React from "react";
 import { reportError } from "@/reporting/errors-lazy";
 
+type ErrorBoundaryProps = {
+	children: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+	hasError: boolean;
+};
+
 export class ErrorBoundary extends React.Component<
-	{ children: React.ReactNode },
-	{ hasError: boolean }
+	ErrorBoundaryProps,
+	ErrorBoundaryState
 > {
-	constructor(props: { children: React.ReactNode }) {
+	constructor(props: ErrorBoundaryProps) {
 		super(props);
 		this.state = { hasError: false };
 	}
@@ -16,7 +24,23 @@ export class ErrorBoundary extends React.Component<
 		reportError(error, { errorInfo });
 	}
 	render() {
-		if (this.state.hasError) return <div>Something went wrong.</div>;
+		if (this.state.hasError) {
+			return (
+				<div className="flex flex-col items-center justify-center min-h-[200px] gap-4 p-8 text-center">
+					<h2 className="text-lg font-semibold">Something went wrong</h2>
+					<p className="text-sm opacity-70">
+						An unexpected error occurred. Please try again.
+					</p>
+					<button
+						type="button"
+						className="btn-primary"
+						onClick={() => this.setState({ hasError: false })}
+					>
+						Try again
+					</button>
+				</div>
+			);
+		}
 		return this.props.children;
 	}
 }


### PR DESCRIPTION
  - CopyButton: show "Failed to copy" feedback when clipboard API is unavailable
  - ErrorBoundary: add recovery UI with description and "Try again" button
  - AdSlot: log fallback bid errors to console instead of silently swallowing