### PR TITLE
test: add unit tests for schemas, httpError, CopyButton, ErrorBoundary

### DIFF
--- a/src/components/ui/CopyButton.test.tsx
+++ b/src/components/ui/CopyButton.test.tsx
@@ -1,0 +1,64 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CopyButton from "./CopyButton";
+
+afterEach(cleanup);
+
+describe("CopyButton", () => {
+	it("renders with default label", () => {
+		render(<CopyButton text="hello" />);
+		expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+	});
+
+	it("shows 'Copied!' after successful copy", async () => {
+		Object.assign(navigator, {
+			clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+		});
+
+		render(<CopyButton text="hello" />);
+		fireEvent.click(screen.getByRole("button"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Copied!")).toBeInTheDocument();
+		});
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+	});
+
+	it("shows 'Failed to copy' when clipboard API rejects", async () => {
+		Object.assign(navigator, {
+			clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+		});
+
+		render(<CopyButton text="hello" />);
+		fireEvent.click(screen.getByRole("button"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Failed to copy")).toBeInTheDocument();
+		});
+	});
+
+	it("calls onCopied callback on success", async () => {
+		Object.assign(navigator, {
+			clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+		});
+		const onCopied = vi.fn();
+
+		render(<CopyButton text="hello" onCopied={onCopied} />);
+		fireEvent.click(screen.getByRole("button"));
+
+		await waitFor(() => {
+			expect(onCopied).toHaveBeenCalledOnce();
+		});
+	});
+
+	it("has aria-live for accessibility", () => {
+		render(<CopyButton text="hello" />);
+		expect(screen.getByRole("button")).toHaveAttribute("aria-live", "polite");
+	});
+});

--- a/src/features/auth/schemas.test.ts
+++ b/src/features/auth/schemas.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { LoginSchema, RegisterSchema } from "./schemas";
+
+describe("LoginSchema", () => {
+	it("accepts valid credentials", () => {
+		const result = LoginSchema.safeParse({
+			email: "user@example.com",
+			password: "secret123",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("trims email whitespace", () => {
+		const result = LoginSchema.safeParse({
+			email: "  user@example.com  ",
+			password: "secret123",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.email).toBe("user@example.com");
+		}
+	});
+
+	it("rejects invalid email", () => {
+		const result = LoginSchema.safeParse({
+			email: "not-an-email",
+			password: "secret123",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe("Enter a valid email");
+		}
+	});
+
+	it("rejects empty email", () => {
+		const result = LoginSchema.safeParse({ email: "", password: "secret123" });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects short password", () => {
+		const result = LoginSchema.safeParse({
+			email: "user@example.com",
+			password: "12345",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe(
+				"Password must be at least 6 characters",
+			);
+		}
+	});
+
+	it("rejects empty password", () => {
+		const result = LoginSchema.safeParse({
+			email: "user@example.com",
+			password: "",
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("RegisterSchema", () => {
+	const valid = {
+		name: "John",
+		email: "john@example.com",
+		password: "secret123",
+		confirmPassword: "secret123",
+	};
+
+	it("accepts valid registration data", () => {
+		const result = RegisterSchema.safeParse(valid);
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects short name", () => {
+		const result = RegisterSchema.safeParse({ ...valid, name: "J" });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe(
+				"Name must be at least 2 characters",
+			);
+		}
+	});
+
+	it("trims name whitespace", () => {
+		const result = RegisterSchema.safeParse({ ...valid, name: "  Jo  " });
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.name).toBe("Jo");
+		}
+	});
+
+	it("rejects mismatched passwords", () => {
+		const result = RegisterSchema.safeParse({
+			...valid,
+			confirmPassword: "different",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toBe("Passwords must match");
+		}
+	});
+
+	it("rejects invalid email", () => {
+		const result = RegisterSchema.safeParse({ ...valid, email: "bad" });
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects short password", () => {
+		const result = RegisterSchema.safeParse({
+			...valid,
+			password: "123",
+			confirmPassword: "123",
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/lib/httpError.test.ts
+++ b/src/lib/httpError.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { toMessage } from "./httpError";
+
+describe("toMessage", () => {
+	it("extracts message from Error instance", () => {
+		expect(toMessage(new Error("boom"))).toBe("boom");
+	});
+
+	it("returns string errors as-is", () => {
+		expect(toMessage("something broke")).toBe("something broke");
+	});
+
+	it("extracts message from plain object", () => {
+		expect(toMessage({ message: "not found" })).toBe("not found");
+	});
+
+	it("returns fallback for null", () => {
+		expect(toMessage(null)).toBe("Request failed");
+	});
+
+	it("returns fallback for undefined", () => {
+		expect(toMessage(undefined)).toBe("Request failed");
+	});
+
+	it("returns fallback for number", () => {
+		expect(toMessage(42)).toBe("Request failed");
+	});
+
+	it("returns custom fallback", () => {
+		expect(toMessage(null, "Custom error")).toBe("Custom error");
+	});
+
+	it("returns fallback for object with empty message", () => {
+		expect(toMessage({ message: "  " })).toBe("Request failed");
+	});
+
+	it("returns fallback for object without message", () => {
+		expect(toMessage({ code: 500 })).toBe("Request failed");
+	});
+});

--- a/src/reporting/ErrorBoundary.test.tsx
+++ b/src/reporting/ErrorBoundary.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+vi.mock("@/reporting/errors-lazy", () => ({
+	reportError: vi.fn(),
+}));
+
+let shouldThrow = false;
+
+function ThrowingChild() {
+	if (shouldThrow) throw new Error("test error");
+	return <div>Child content</div>;
+}
+
+afterEach(() => {
+	shouldThrow = false;
+	cleanup();
+});
+
+describe("ErrorBoundary", () => {
+	it("renders children when no error", () => {
+		render(
+			<ErrorBoundary>
+				<div>Hello</div>
+			</ErrorBoundary>,
+		);
+		expect(screen.getByText("Hello")).toBeInTheDocument();
+	});
+
+	it("shows fallback UI when child throws", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		shouldThrow = true;
+
+		render(
+			<ErrorBoundary>
+				<ThrowingChild />
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+		expect(
+			screen.getByText("An unexpected error occurred. Please try again."),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Try again" }),
+		).toBeInTheDocument();
+
+		vi.restoreAllMocks();
+	});
+
+	it("recovers when 'Try again' is clicked", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		shouldThrow = true;
+
+		render(
+			<ErrorBoundary>
+				<ThrowingChild />
+			</ErrorBoundary>,
+		);
+
+		expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+		shouldThrow = false;
+		fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+		expect(screen.getByText("Child content")).toBeInTheDocument();
+
+		vi.restoreAllMocks();
+	});
+
+	it("has accessible button with type='button'", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		shouldThrow = true;
+
+		render(
+			<ErrorBoundary>
+				<ThrowingChild />
+			</ErrorBoundary>,
+		);
+
+		const btn = screen.getByRole("button", { name: "Try again" });
+		expect(btn).toHaveAttribute("type", "button");
+
+		vi.restoreAllMocks();
+	});
+});


### PR DESCRIPTION
  - Auth schemas: 12 tests for login/register Zod validation (email, password, name, confirmPassword)
  - httpError.toMessage: 9 tests for all input types (Error, string, object, null, undefined)
  - CopyButton: 5 tests for clipboard success/failure feedback and accessibility
  - ErrorBoundary: 4 tests for rendering, error fallback UI, recovery, and button type